### PR TITLE
Enable composing partials for the same field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ version links.
 
 [commits]: https://github.com/seanpdoyle/view_partial_form_builder/commits/master
 
+## master
+
+Passing a `partial:` key can be useful for layering partials on top of one
+another. Enable rendering partials within partials:
+
+```html+erb
+<%# app/views/admin/form_builder/_search_field.html.erb %>
+
+<%= form.search_field(
+  *arguments,
+  partial: "form_builder/search_field",
+  **options.merge_token_lists(
+    class: "search-field--admin",
+    "data-controller": "focus->admin-search#clearResults",
+  ),
+) %>
+```
+
 ## [0.1.0] - April 12, 2020
 
 Construct `<form>` elements and their fields by combining

--- a/README.md
+++ b/README.md
@@ -240,6 +240,59 @@ as the `partial:` option:
 <% end %>
 ```
 
+#### Composing partials
+
+Passing a `partial:` key can be useful for layering partials on top of one
+another. For instance, consider an administrative interface that shares styles
+with a consumer facing site, but has additional bells and whistles.
+
+Declare the consumer facing inputs (in this example, `<input type="search">`):
+
+```html+erb
+<%# app/views/form_builder/_search_field.html.erb %>
+
+<%= form.search_field(
+  *arguments,
+  **options.merge_token_lists(
+    class: "search-field",
+    "data-controller": "input->search#executeQuery",
+  ),
+) %>
+```
+
+Then, declare the administrative interface's inputs, in terms of overriding the
+foundation built by the more general definitions:
+
+```html+erb
+<%# app/views/admin/form_builder/_search_field.html.erb %>
+
+<%= form.search_field(
+  *arguments,
+  partial: "form_builder/search_field",
+  **options.merge_token_lists(
+    class: "search-field--admin",
+    "data-controller": "focus->admin-search#clearResults",
+  ),
+) %>
+```
+
+The rendered `admin/form_builder/search_field` partial combines options and
+arguments from both partials:
+
+```html
+<input
+  type="search"
+  class="
+    search-field
+    search-field--admin
+  "
+  data-controller="
+    input->search#executeQuery
+    focus->admin-search#clearResults
+  "
+>
+```
+
 ### Configuration
 
 View partials lookup and resolution will be scoped to the


### PR DESCRIPTION
Background
---

Prior to this commit, the `ViewPartialFormBuilder::FormBuilder` would
guard rendering view partials with a `#about_to_recurse_infinitely?`
guard. The guard was in place to prevent self-referential infinite
recursions like the following:

```html+erb
<%# app/views/form_builder/_label.html.erb %>

<%= form.label(
  *arguments,
  partial: "form_builder/label",
  **options,
  &block
) %>
```

To counteract that, after the first invocation, the `form` variable made
available to the `form_builder/label` partial was replaced with an
instance of [`ActionView::Helpers::FormBuilder`][form_builder], instead
of the `ViewPartialFormBuilder::FormBuilder` instance.

Problem
---

Passing a `partial:` key would be useful for layering partials on top of
one another. For instance, consider an administrative interface that
shared styles with a consumer facing site, but had additional bells and
whistles.

Solution
---

Extend the `ViewPartialFormBuilder::FormBuilder`'s check for
`#about_to_recurse_infinitely?` to allow for matching field names when a
`partial:` option is present.

Preventing infinite recursion is still of the utmost importance.
However, if a `partial:` option is present, check for it being a
[different `virtual_path`][actionview] than the current render, and
allow it when we're sure the next render cycle won't be
self-referential.

[form_builder]: https://api.rubyonrails.org/v6.0/classes/ActionView/Helpers/FormHelper.html
[actionview]: https://api.rubyonrails.org/classes/ActionView/Base.html