### PR TITLE
Deprecate `merge_token_lists`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ version links.
 
 ## main
 
+Deprecate the use of `merge_token_lists` to combine attributes that are backed
+by [DOMTokenList][]. It will be removed in the `0.2.0` release.
+
+[DOMTokenList]: https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList
+
 ## [0.1.4] - August 06, 2020
 
 Improve support for `fields_for` and `fields` calls to cascade partial

--- a/README.md
+++ b/README.md
@@ -158,16 +158,12 @@ When rendering a field's DOMTokenList-backed attributes (like `class` or
 controllers][stimulus-controller]), transforming and combining singular `String`
 instances into lists of token can be very useful.
 
-To simplify those scenarios, a partial's template-local optional attributes are
-made available with the `#merge_token_lists` method.
-
 These optional attributes are available through the `options` or `html_options`
 partial-local variables. Their name will depend on the partial's corresponding
 [`ActionView::Helpers::FormBuilder`][FormBuilder] interface.
 
-Calls to `#merge_token_lists` will merge the key-value pairs and return a new
-Hash-like structure. The attribute's value will be transformed into an `Array`.
-Given call to `form.text_field` and a corresponding partial declaration:
+To "merge" attributes together, you can combine Ruby's `String` interpolation
+and `Hash#delete`:
 
 ```html+erb
   <%# app/views/users/new.html.erb %>
@@ -177,7 +173,11 @@ Given call to `form.text_field` and a corresponding partial declaration:
 
 <# app/views/form_builder/_text_field.html.erb %>
 
-<%= form.text_field(*arguments, **options.merge_token_lists(class: "text-field")) %>
+<%= form.text_field(
+  method,
+  class: "text-field #{options.delete(:class)}",
+  **options
+) %>
 ```
 
 The resulting HTML `<input>` element will merge have its [`class`

--- a/lib/view_partial_form_builder/html_attributes.rb
+++ b/lib/view_partial_form_builder/html_attributes.rb
@@ -1,5 +1,13 @@
 module ViewPartialFormBuilder
   class HtmlAttributes
+    deprecate merge_token_lists: <<~'WARNING', deprecator: ActiveSupport::Deprecation.new("0.2.0", "ViewPartialFormBuilder")
+
+      As an alternative, merge arguments through String interpolation:
+
+      <%= form.label(method, class: "label #{options.delete(:class)}", **options) %>
+
+    WARNING
+
     def initialize(**attributes)
       @attributes = attributes
     end


### PR DESCRIPTION
Deprecate the use of `merge_token_lists` to combine attributes that are
backed by [DOMTokenList][].

Unfortunately, the introduction of the
`HtmlAttributes#merge_token_lists` convenience method is seemingly
pre-mature, and doesn't provide enough intrinsic value to offset its
maintenance footprint.

It will be removed in the `0.2.0` release.

[DOMTokenList]: https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList