### PR TITLE
Deprecate the `partial:` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ version links.
 
 ## main
 
+Deprecate the use of `partial:` to override which partial to be rendered by
+`ViewPartialFormBuilder::FormBuilder`. Instead, rely on Rails' controller and
+ActiveModel partial scope resolution prefixing.
+
 Deprecate the use of `merge_token_lists` to combine attributes that are backed
 by [DOMTokenList][]. It will be removed in the `0.2.0` release.
 

--- a/README.md
+++ b/README.md
@@ -229,22 +229,37 @@ For example, when calling `form_with(model: User.new)`, a partial declared in
 </div>
 ```
 
-If you'd like to render a specific partial for a field, you can declare the name
-as the `partial:` option:
+If you'd like to render a specific partial for a field, make sure that you pass
+along the `form:` (along with any other partial-local variables) as part of the
+`render` call's `locals:` option:
+
 
 ```erb
 <%# app/views/users/new.html.erb %>
 
 <%= form_with(model: User.new) do |form| %>
-  <%= form.email_field(:email, partial: "emails/my_special_text_field") %>
+  <%= render("emails/my_special_email_field", {
+    form: form,
+    method: :email,
+    options: { class: "user-email" },
+  ) %>
 <% end %>
+
+<%# app/views/emails/_my_special_email_field.html.erb %>
+
+<%= form.email_field(
+  method,
+  class: "my-special-email #{options.delete(:class)},
+  **options
+) %>
 ```
 
 #### Composing partials
 
-Passing a `partial:` key can be useful for layering partials on top of one
-another. For instance, consider an administrative interface that shares styles
-with a consumer facing site, but has additional bells and whistles.
+Layering partials on top of one another can be useful to share foundational
+styles and configuration across your fields. For instance, consider an
+administrative interface that shares styles with a consumer facing site, but has
+additional bells and whistles.
 
 Declare the consumer facing inputs (in this example, `<input type="search">`):
 
@@ -252,11 +267,10 @@ Declare the consumer facing inputs (in this example, `<input type="search">`):
 <%# app/views/form_builder/_search_field.html.erb %>
 
 <%= form.search_field(
-  *arguments,
-  **options.merge_token_lists(
-    class: "search-field",
-    "data-controller": "input->search#executeQuery",
-  ),
+  method,
+  class: "search-field #{options.delete(:class}",
+  "data-controller": "input->search#executeQuery #{options.delete(:"data-controller")}",
+  **options
 ) %>
 ```
 
@@ -267,12 +281,9 @@ foundation built by the more general definitions:
 <%# app/views/admin/form_builder/_search_field.html.erb %>
 
 <%= form.search_field(
-  *arguments,
-  partial: "form_builder/search_field",
-  **options.merge_token_lists(
-    class: "search-field--admin",
-    "data-controller": "focus->admin-search#clearResults",
-  ),
+  method,
+  class: "search-field--admin #{options.delete(:class}",
+  "data-controller": "focus->admin-search#clearResults #{options.delete(:"data-controller")}",
 ) %>
 ```
 

--- a/lib/view_partial_form_builder/form_builder.rb
+++ b/lib/view_partial_form_builder/form_builder.rb
@@ -264,6 +264,10 @@ module ViewPartialFormBuilder
       locals = objectify_options(options).merge(locals, form: self)
 
       partial = if partial_override.present?
+        ActiveSupport::Deprecation.new("0.2.0", "ViewPartialFormBuilder").warn(<<~WARNING)
+          Providing a `partial:` option for a form field is deprecated.
+        WARNING
+
         find_partial(partial_override, locals, prefixes: [])
       else
         find_partial(field, locals, prefixes: prefixes_after(field))


### PR DESCRIPTION
Deprecate the use of `partial:` to override which partial to be rendered
by `ViewPartialFormBuilder::FormBuilder`. Instead, rely on Rails'
controller and ActiveModel partial scope resolution prefixing.

Unfortunately, the introduction of the `partial:` partial resolution
override was pre-mature, and doesn't provide enough intrinsic value to
offset its deviation from most `ActionView::Helpers::FormBuilder`
methods' supported `options` and `html_options`.

It will be removed in the 0.2.0 release.