### PR TITLE
Remove support for `partial:` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ version links.
 
 ## main
 
+Remove support for `partial:` option to override which partial is to be rendered
+by `ViewPartialFormBuilder::FormBuilder`.
+
 Remove support for declaring option keys as partial-local variables.
 
 Remove support for `*arguments` in a view partial.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ In addition, each view partial receives:
 * `form` - a reference to the instance of `ViewPartialFormBuilder`, which is a
   descendant of [`ActionView::Helpers::FormBuilder`][FormBuilder]
 
-* `&block` - a callable, `yield`-able block if the helper method was passed one
+* `block` - the block if the helper method was passed one. Forward it along to
+  field helpers as `&block`.
 
 #### Handling DOMTokenList attributes
 

--- a/lib/view_partial_form_builder/form_builder.rb
+++ b/lib/view_partial_form_builder/form_builder.rb
@@ -224,18 +224,9 @@ module ViewPartialFormBuilder
 
     def render_partial(field, locals, fallback:, &block)
       options = objectify_options(locals.fetch(:options, {}))
-      partial_override = options.delete(:partial)
       locals = locals.merge(form: self)
 
-      partial = if partial_override.present?
-        ActiveSupport::Deprecation.new("0.2.0", "ViewPartialFormBuilder").warn(<<~WARNING)
-          Providing a `partial:` option for a form field is deprecated.
-        WARNING
-
-        find_partial(partial_override, locals, prefixes: [])
-      else
-        find_partial(field, locals, prefixes: prefixes_after(field))
-      end
+      partial = find_partial(field, locals, prefixes: prefixes_after(field))
 
       if partial.nil? || about_to_recurse_infinitely?(partial)
         fallback.call

--- a/test/integration/view_partial_form_builder_test.rb
+++ b/test/integration/view_partial_form_builder_test.rb
@@ -201,26 +201,6 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
     assert_select(".post-input")
   end
 
-  test "specifying a partial name" do
-    declare_template "application/_form.html.erb", <<~HTML
-      <%= form_with(model: Post.new) do |form| %>
-        <%= form.text_field :name, partial: "special_posts/text_field" %>
-      <% end %>
-    HTML
-    declare_template "form_builder/_text_field.html.erb", <<~HTML
-      <input type="text" class="application-text-field">
-    HTML
-    declare_template "special_posts/_text_field.html.erb", <<~HTML
-      <p class="partial"><%= local_assigns[:partial] %></p>
-      <input type="text" class="special-post-text-field">
-    HTML
-
-    render(partial: "application/form")
-
-    assert_select(".special-post-text-field")
-    assert_select(".partial", text: "")
-  end
-
   test "exposes a the default helper's arguments and options to template as locals" do
     declare_template "application/_form.html.erb", <<~HTML
       <%= form_with(model: Post.new) do |form| %>
@@ -261,9 +241,8 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
     declare_template "posts/form_builder/_text_field.html.erb", <<~'HTML'
       <%= form.text_field(
         method,
-        partial: "form_builder/text_field",
-        class: "text--admin-partial #{options.delete(:class)}",
-        **options,
+        class: "text--admin-partial  #{options.delete(:class)}",
+        **options
       ) %>
     HTML
     declare_template "form_builder/_text_field.html.erb", <<~'HTML'


### PR DESCRIPTION
As a follow-up to the deprecation of the `partial:` option, this commit
removes support for overriding the partial to be rendered, and instead
encourages consumers to rely on the most-specific to most-general
partial path resolution chaining.