### PR TITLE
Remove support for *arguments in a view partials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ version links.
 
 ## main
 
+Remove support for `*arguments` in a view partial.
+
 Remove support for `merge_token_lists`.
 
 ## [0.1.5] - August 06, 2020

--- a/lib/view_partial_form_builder/form_builder.rb
+++ b/lib/view_partial_form_builder/form_builder.rb
@@ -26,7 +26,6 @@ module ViewPartialFormBuilder
         text: text,
         options: options,
         block: block,
-        arguments: [method, text],
       }
 
       render_partial("label", locals, fallback: -> { super }, &block)
@@ -38,7 +37,6 @@ module ViewPartialFormBuilder
         options: options,
         checked_value: checked_value,
         unchecked_value: unchecked_value,
-        arguments: [method, options, checked_value, unchecked_value],
       }
 
       render_partial("check_box", locals, fallback: -> { super })
@@ -49,7 +47,6 @@ module ViewPartialFormBuilder
         method: method,
         tag_value: tag_value,
         options: options,
-        arguments: [method, tag_value],
       }
 
       render_partial("radio_button", locals, fallback: -> { super })
@@ -64,7 +61,6 @@ module ViewPartialFormBuilder
         options: options,
         html_options: html_options,
         block: block,
-        arguments: [method, choices, options],
       }
 
       render_partial("select", locals, fallback: -> { super }, &block)
@@ -80,7 +76,6 @@ module ViewPartialFormBuilder
         text_method: text_method,
         options: options,
         html_options: html_options,
-        arguments: [method, collection, value_method, text_method, options],
       }
 
       render_partial("collection_select", locals, fallback: -> { super })
@@ -97,13 +92,6 @@ module ViewPartialFormBuilder
         options: options,
         html_options: html_options,
         block: block,
-        arguments: [
-          method,
-          collection,
-          value_method,
-          text_method,
-          options,
-        ],
       }
 
       render_partial("collection_check_boxes", locals, fallback: -> { super }, &block)
@@ -120,13 +108,6 @@ module ViewPartialFormBuilder
         options: options,
         html_options: html_options,
         block: block,
-        arguments: [
-          method,
-          collection,
-          value_method,
-          text_method,
-          options,
-        ],
       }
 
       render_partial("collection_radio_buttons", locals, fallback: -> { super }, &block)
@@ -144,15 +125,6 @@ module ViewPartialFormBuilder
         option_value_method: option_value_method,
         html_options: html_options,
         options: options,
-        arguments: [
-          method,
-          collection,
-          group_method,
-          group_label_method,
-          option_key_method,
-          option_value_method,
-          options,
-        ],
       }
 
       render_partial("grouped_collection_select", locals, fallback: -> { super })
@@ -166,7 +138,6 @@ module ViewPartialFormBuilder
         priority_zones: priority_zones,
         html_options: html_options,
         options: options,
-        arguments: [method, priority_zones, options],
       }
 
       render_partial("time_zone_select", locals, fallback: -> { super })
@@ -189,7 +160,6 @@ module ViewPartialFormBuilder
       locals = {
         method: method,
         options: options,
-        arguments: [method],
       }
 
       render_partial("hidden_field", locals, fallback: -> { super })
@@ -201,7 +171,6 @@ module ViewPartialFormBuilder
       locals = {
         method: method,
         options: options,
-        arguments: [method],
       }
 
       render_partial("file_field", locals, fallback: -> { super })
@@ -214,7 +183,6 @@ module ViewPartialFormBuilder
       locals = {
         value: value,
         options: options,
-        arguments: [value],
       }
 
       render_partial("submit", locals, fallback: -> { super })
@@ -227,7 +195,6 @@ module ViewPartialFormBuilder
       locals = {
         value: value,
         options: options,
-        arguments: [value],
       }
 
       render_partial("button", locals, fallback: -> { super })
@@ -247,7 +214,6 @@ module ViewPartialFormBuilder
             {
               method: method,
               options: options,
-              arguments: [method],
             },
             fallback: -> { super },
           )
@@ -263,7 +229,7 @@ module ViewPartialFormBuilder
       options_as_locals = objectify_options(options)
       locals = DeprecatedHash.new(
         options_as_locals.merge(locals, form: self),
-        deprecated_keys: options_as_locals.keys + [:arguments],
+        deprecated_keys: options_as_locals.keys,
       )
 
       partial = if partial_override.present?

--- a/test/integration/view_partial_form_builder_test.rb
+++ b/test/integration/view_partial_form_builder_test.rb
@@ -21,7 +21,7 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
     HTML
     declare_template "form_builder/_text_field.html.erb", <<~HTML
       <%= form.label(method) %>
-      <%= form.text_field(*arguments, **options) %>
+      <%= form.text_field(method, **options) %>
     HTML
     declare_template "form_builder/_label.html.erb", <<~HTML
       <label>Label from partial</label>
@@ -44,7 +44,7 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
     HTML
     declare_template "form_builder/_text_field.html.erb", <<~'HTML'
       <%= form.text_field(
-        *arguments,
+        method,
         class: "text-field #{options.delete(:class)}",
         **options,
       ) %>
@@ -268,7 +268,7 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
       <% end %>
     HTML
     declare_template "form_builder/_text_field.html.erb", <<~HTML
-      <%= form.text_field(*arguments, **options) %>
+      <%= form.text_field(method, **options) %>
     HTML
 
     render(partial: "application/form")
@@ -300,7 +300,7 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
     HTML
     declare_template "posts/form_builder/_text_field.html.erb", <<~'HTML'
       <%= form.text_field(
-        *arguments,
+        method,
         partial: "form_builder/text_field",
         class: "text--admin-partial #{options.delete(:class)}",
         **options,
@@ -308,7 +308,7 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
     HTML
     declare_template "form_builder/_text_field.html.erb", <<~'HTML'
       <%= form.text_field(
-        *arguments,
+        method,
         class: "text #{options.delete(:class)}",
         **options,
       ) %>
@@ -327,7 +327,7 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
     HTML
     declare_template "form_builder/_text_field.html.erb", <<~'HTML'
       <%= form.text_field(
-        *arguments,
+        method,
         partial: "form_builder/text_field",
         class: "text #{options.delete(:class)}",
         **options,
@@ -335,7 +335,7 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
     HTML
     declare_template "posts/form_builder/_text_field.html.erb", <<~'HTML'
       <%= form.text_field(
-        *arguments,
+        method,
         partial: "form_builder/text_field",
         class: "text--post #{options.delete(:class)}",
         **options,

--- a/test/view_partial_form_builder/label_test.rb
+++ b/test/view_partial_form_builder/label_test.rb
@@ -91,7 +91,7 @@ class ViewPartialFormBuilderLabelTest < FormBuilderTestCase
       <% end %>
     HTML
     declare_template "form_builder/_label.html.erb", <<~HTML
-      <%= form.label(*arguments, **options, &block) %>
+      <%= form.label(method, **options, &block) %>
     HTML
 
     render(partial: "application/form")

--- a/test/view_partial_form_builder/select_test.rb
+++ b/test/view_partial_form_builder/select_test.rb
@@ -89,7 +89,9 @@ class ViewPartialFormBuilderSelectTest < FormBuilderTestCase
     HTML
     declare_template "form_builder/_select.html.erb", <<~'HTML'
       <%= form.select(
-        *arguments,
+        method,
+        choices,
+        options,
         class: "select #{html_options.delete(:class)}",
         **html_options,
         &block


### PR DESCRIPTION
As a follow-up to its deprecation, this commit removes support for
splatting `*arguments` in view partials.