### PR TITLE
Add missing support for `date_select` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ version links.
 
 ## main
 
+Add missing support for `date_select` method.
+
+[date_select]: https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-date_select
+
 Use [ActionView::Template][] instances to render templates instead of
 [ActionView::Helpers::RenderingHelper][]-provided `render()` method.
 

--- a/lib/view_partial_form_builder/form_builder.rb
+++ b/lib/view_partial_form_builder/form_builder.rb
@@ -173,6 +173,17 @@ module ViewPartialFormBuilder
       render_partial("time_zone_select", locals, fallback: -> { super })
     end
 
+    def date_select(method, options = {}, **html_options)
+      locals = {
+        method: method,
+        options: options,
+        html_options: HtmlAttributes.new(html_options),
+        arguments: [method, options, html_options],
+      }
+
+      render_partial("date_select", locals, fallback: -> { super })
+    end
+
     def hidden_field(method, **options)
       @emitted_hidden_id = true if method == :id
 

--- a/test/view_partial_form_builder/date_select_test.rb
+++ b/test/view_partial_form_builder/date_select_test.rb
@@ -1,0 +1,59 @@
+require "form_builder_test_case"
+
+class ViewPartialFormBuilderDateSelectTest < FormBuilderTestCase
+  test "renders defaults when overrides are not declared" do
+    render(inline: <<~ERB)
+      <%= form_with(model: Post.new) do |form| %>
+        <%= form.date_select(
+          :start_date,
+          {
+            prompt: true,
+            order: [:year],
+            start_year: 2000,
+            end_year: 2001,
+          },
+          {}
+        ) %>
+      <% end %>
+    ERB
+
+    assert_select %(option[value=""]), count: 1
+    assert_select %(option[value="2000"]), text: "2000"
+    assert_select %(option[value="2001"]), text: "2001"
+  end
+
+  test "renders arguments as local assigns" do
+    declare_template "form_builder/_date_select.html.erb", <<~'HTML'
+      <%= form.date_select(
+        method,
+        options.merge(
+          prompt: true,
+          order: [:year],
+          start_year: 2000,
+        ),
+        class: "year #{html_options.delete(:class)}",
+        **html_options
+      ) %>
+    HTML
+
+    render(inline: <<~ERB)
+      <%= form_with(model: Post.new) do |form| %>
+        <%= form.date_select(
+          :start_date,
+          {
+            order: [:year],
+            end_year: 2001,
+          },
+          class: "post-year",
+          "data-attr": "foo",
+        ) %>
+      <% end %>
+    ERB
+
+    assert_select %(select[class~="year"][class~="post-year"][data-attr="foo"]) do
+      assert_select %(option[value=""]), count: 1
+      assert_select %(option[value="2000"]), text: "2000"
+      assert_select %(option[value="2001"]), text: "2001"
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit, a corresponding implementation for
[ActionView::Helpers::FormBuilder#date_select][date_select] was omitted.

This commit corrects that oversight.

[date_select]: https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-date_select