### PR TITLE
Ensure fields_for and fields can compose partials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ version links.
 
 ## main
 
+Improve support for `fields_for` and `fields` calls to cascade partial
+resolution from most-specific to most-general.
+
 ## [0.1.3] - August 05, 2020
 
 Add missing support for `date_select` method.

--- a/README.md
+++ b/README.md
@@ -293,6 +293,37 @@ arguments from both partials:
 >
 ```
 
+When constructing fields within a `form_with(model: ...)` block, partials will
+use the `model:` instance's [`tableize`-d model name][tableize] to resolve
+partials.
+
+For example, `posts/form_builder/_text_field.html.erb` will be resolved ahead of
+`form_builder/_text_field.html.erb`:
+
+```html+erb
+<%# app/views/posts/form_builder/_text_field.html.erb %>
+
+<%= form.text_field(method, class: "post-text #{options.delete(:class)}", **options) %>
+
+<%# app/views/application/form_builder/_text_field.html.erb %>
+
+<%= form.text_field(method, class: "text #{options.delete(:class)}", **options) %>
+```
+
+The rendered `posts/form_builder/text_field` partial could combine options and
+arguments from both partials:
+
+```html
+<input type="text" class="post-text text">
+```
+
+Models declared within modules will be delimited with `/`. For example,
+`Special::Post` instances would first resolve partials within the
+`app/views/special/posts/form_builder` directory, before falling back to
+`app/views/application/form_builder`.
+
+[tableize]: https://api.rubyonrails.org/classes/String.html#method-i-tableize
+
 ### Configuration
 
 View partials lookup and resolution will be scoped to the

--- a/lib/view_partial_form_builder/form_builder.rb
+++ b/lib/view_partial_form_builder/form_builder.rb
@@ -16,7 +16,7 @@ module ViewPartialFormBuilder
       )
       @lookup_override = LookupOverride.new(
         prefixes: @template.lookup_context.prefixes,
-        object_name: @object_name,
+        object_name: object&.model_name || object_name,
         view_partial_directory: ViewPartialFormBuilder.view_partial_directory,
       )
     end

--- a/lib/view_partial_form_builder/lookup_override.rb
+++ b/lib/view_partial_form_builder/lookup_override.rb
@@ -1,7 +1,7 @@
 module ViewPartialFormBuilder
   class LookupOverride
     def initialize(prefixes:, object_name:, view_partial_directory:)
-      @object_name = object_name.to_s.pluralize
+      @object_name = object_name.to_s.tableize
       @prefixes = prefixes
       @view_partial_directory = view_partial_directory
     end

--- a/test/dummy/app/models/special/post.rb
+++ b/test/dummy/app/models/special/post.rb
@@ -1,0 +1,4 @@
+module Special
+  class Post < ::Post
+  end
+end

--- a/test/view_partial_form_builder/fields_for_test.rb
+++ b/test/view_partial_form_builder/fields_for_test.rb
@@ -32,6 +32,26 @@ class FieldsForTest < FormBuilderTestCase
     assert_select("p", text: "name")
   end
 
+  test "#fields_for cascades templates from most-specific to most general" do
+    declare_template "posts/form_builder/_text_field.html.erb", <<~'HTML'
+      <%= form.text_field(method, class: "post-text #{options.delete(:class)}", **options) %>
+    HTML
+    declare_template "application/form_builder/_text_field.html.erb", <<~'HTML'
+      <%= form.text_field(method, class: "text #{options.delete(:class)}", **options) %>
+    HTML
+    post = Post.new(name: "The Post Name")
+
+    render(locals: {post: post}, inline: <<~HTML)
+      <%= form_with(url: "#") do |form| %>
+        <%= form.fields_for(:post, post) do |post_form| %>
+          <%= post_form.text_field(:name, class: "name-text") %>
+        <% end %>
+      <% end %>
+    HTML
+
+    assert_select %([class~="text"][class~="post-text"][class~="name-text"]), value: post.name
+  end
+
   test "#fields passes an instance of ViewPartialFormBuilder to the block" do
     declare_template "application/_form.html.erb", <<~HTML
       <%= form_with(model: Post.new) do |form| %>
@@ -47,5 +67,25 @@ class FieldsForTest < FormBuilderTestCase
     render(partial: "application/form")
 
     assert_select("p", text: "name")
+  end
+
+  test "#fields cascades templates from most-specific to most general" do
+    declare_template "posts/form_builder/_text_field.html.erb", <<~'HTML'
+      <%= form.text_field(method, class: "post-text #{options.delete(:class)}", **options) %>
+    HTML
+    declare_template "application/form_builder/_text_field.html.erb", <<~'HTML'
+      <%= form.text_field(method, class: "text #{options.delete(:class)}", **options) %>
+    HTML
+    post = Post.new(name: "The Post Name")
+
+    render(locals: {post: post}, inline: <<~HTML)
+      <%= form_with(url: "#") do |form| %>
+        <%= form.fields(model: post) do |post_form| %>
+          <%= post_form.text_field(:name, class: "name-text") %>
+        <% end %>
+      <% end %>
+    HTML
+
+    assert_select %([class~="text"][class~="post-text"][class~="name-text"]), value: post.name
   end
 end


### PR DESCRIPTION
Improve support for `fields_for` and `fields` calls to cascade partial
resolution from most-specific to most-general.

Prior to this commit, nested forms would use the _object name_ to
attempt to resolve partial paths. For example, a `form_with(model:
Post.new)` that nested a form constructed with `fields(model: User.new)`
would use pass along `user[post]` as the object name, instead of `post`.

To resolve that issue, attempt to use the [`tableize`-d
version][tableize] of the [`model_name`][model_name] (when available),
and then fall back to the `object_name` value.

[tableize]: https://api.rubyonrails.org/classes/String.html#method-i-tableize
[model_name]: https://api.rubyonrails.org/classes/ActiveModel/Naming.html#method-i-model_name