### PR TITLE
Deprecate support of option keys as partial-locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ version links.
 
 ## main
 
+Deprecate support for declaring options keys as partial-local variables.
+It will be removed in the `0.2.0` release.
+
 Deprecate support for `*arguments` in a view partial.
 
 It will be removed in the `0.2.0` release.

--- a/lib/view_partial_form_builder/form_builder.rb
+++ b/lib/view_partial_form_builder/form_builder.rb
@@ -261,9 +261,10 @@ module ViewPartialFormBuilder
     def render_partial(field, locals, fallback:, &block)
       options = locals.fetch(:options, {})
       partial_override = options.delete(:partial)
+      options_as_locals = objectify_options(options)
       locals = DeprecatedHash.new(
-        objectify_options(options).merge(locals, form: self),
-        deprecated_keys: [:arguments],
+        options_as_locals.merge(locals, form: self),
+        deprecated_keys: options_as_locals.keys + [:arguments],
       )
 
       partial = if partial_override.present?


### PR DESCRIPTION
Partials are better off forwarding along arguments with names based on
the API they wrap, and only those parameters as template-local values.

For instance, expecting `object_name` to be available directly, instead
of `form.object_name` increases the partials' public API surface area by
too much without providing enough intrinsic value. Also, it increases
the likelihood of unknowingly colliding variable names with option keys
that the private API expects to be present.

It will be removed in the 0.2.0 release.