### PR TITLE
Remove support of option keys as partial-locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ version links.
 
 ## main
 
+Remove support for declaring option keys as partial-local variables.
+
 Remove support for `*arguments` in a view partial.
 
 Remove support for `merge_token_lists`.

--- a/lib/view_partial_form_builder/form_builder.rb
+++ b/lib/view_partial_form_builder/form_builder.rb
@@ -148,7 +148,6 @@ module ViewPartialFormBuilder
         method: method,
         options: options,
         html_options: html_options,
-        arguments: [method, options, html_options],
       }
 
       render_partial("date_select", locals, fallback: -> { super })
@@ -224,13 +223,9 @@ module ViewPartialFormBuilder
     private
 
     def render_partial(field, locals, fallback:, &block)
-      options = locals.fetch(:options, {})
+      options = objectify_options(locals.fetch(:options, {}))
       partial_override = options.delete(:partial)
-      options_as_locals = objectify_options(options)
-      locals = DeprecatedHash.new(
-        options_as_locals.merge(locals, form: self),
-        deprecated_keys: options_as_locals.keys,
-      )
+      locals = locals.merge(form: self)
 
       partial = if partial_override.present?
         ActiveSupport::Deprecation.new("0.2.0", "ViewPartialFormBuilder").warn(<<~WARNING)
@@ -289,24 +284,6 @@ module ViewPartialFormBuilder
       else
         @template.instance_values["virtual_path"].to_s
       end
-    end
-  end
-
-  class DeprecatedHash < Hash
-    def initialize(hash, deprecated_keys: [])
-      super()
-      merge!(hash)
-      @deprecated_keys = deprecated_keys
-    end
-
-    def [](key)
-      if @deprecated_keys.include?(key)
-        ActiveSupport::Deprecation.new("0.2.0", "ViewPartialFormBuilder").warn <<~WARNING
-          Accessing `#{key}` from partials is deprecated.
-        WARNING
-      end
-
-      super
     end
   end
 end

--- a/test/integration/view_partial_form_builder_test.rb
+++ b/test/integration/view_partial_form_builder_test.rb
@@ -186,46 +186,6 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
     assert_select(".post-input")
   end
 
-  test "interpolates local variables from the arguments into model-specific partial" do
-    post = Post.new(name: "custom value")
-    declare_template "posts/_form.html.erb", <<~HTML
-      <%= form_with(model: post) do |form| %>
-        <%= form.text_field :name %>
-      <% end %>
-    HTML
-    declare_template "posts/form_builder/_text_field.html.erb", <<~HTML
-      <input
-        type="text"
-        class="<%= form.object_name %>-input"
-        value="<%= object.name %>"
-      >
-    HTML
-
-    render(partial: "posts/form", locals: { post: post })
-
-    assert_select %([class="post-input"][value="#{post.name}"])
-  end
-
-  test "interpolates local variables from the arguments into fallback partial" do
-    post = Post.new(name: "custom value")
-    declare_template "application/_form.html.erb", <<~HTML
-      <%= form_with(model: post) do |form| %>
-        <%= form.text_field :name %>
-      <% end %>
-    HTML
-    declare_template "form_builder/_text_field.html.erb", <<~HTML
-      <input
-        type="text"
-        class="<%= form.object_name %>-input"
-        value="<%= object.name %>"
-      >
-    HTML
-
-    render(partial: "application/form", locals: { post: post })
-
-    assert_select %([class="post-input"][value="#{post.name}"])
-  end
-
   test "interpolates `options` variable" do
     declare_template "application/_form.html.erb", <<~HTML
       <%= form_with(model: Post.new) do |form| %>


### PR DESCRIPTION
As a follow-up to its deprecation, this commit removes support for
declaring option keys as partial-local variables.