### PR TITLE
Deprecate root-level directory declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ version links.
 
 ## main
 
+Deprecate root-level declarations in `app/views/form_builder/` in favor of
+`app/views/application/form_builder/`.
+
 Deprecate support for declaring options keys as partial-local variables.
 It will be removed in the `0.2.0` release.
 

--- a/lib/view_partial_form_builder/form_builder.rb
+++ b/lib/view_partial_form_builder/form_builder.rb
@@ -292,7 +292,15 @@ module ViewPartialFormBuilder
         prefixes,
         template_is_partial,
         locals.keys,
-      ).first
+      ).first.tap do |partial|
+        root_directory = ViewPartialFormBuilder.view_partial_directory
+
+        if partial&.virtual_path == "#{root_directory}/_#{template_name}"
+          ActiveSupport::Deprecation.new("0.2.0", "ViewPartialFormBuilder").warn(<<~WARNING.strip)
+            Declare root-level partials in app/views/application/#{root_directory}/, not app/views/#{root_directory}/.
+          WARNING
+        end
+      end
     end
 
     def prefixes_after(template_name)


### PR DESCRIPTION
Deprecate root-level declarations in `app/views/form_builder/` in favor
of `app/views/application/form_builder/`.

During controller-based rendering, the prefixes are most likely to
contain an `application/` directory, since most controllers inherit from
`ApplicationController`.

This deprecation is meant to encourage developers to structure their
ViewPartialFormBuilder partials to fit within that structure.