### PR TITLE
Prefix root partial directory with application/

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Next, declare view partials that correspond to the [`FormBuilder`][FormBuilder]
 helper method you'd like to have more control over:
 
 ```html+erb
-<%# app/views/form_builder/_text_field.html.erb %>
+<%# app/views/application/form_builder/_text_field.html.erb %>
 
 <input
   type="text"
@@ -48,7 +48,7 @@ helper method you'd like to have more control over:
 <% end %>
 >
 
-<%# app/views/form_builder/_email_field.html.erb %>
+<%# app/views/application/form_builder/_email_field.html.erb %>
 
 <input
   type="email"
@@ -59,7 +59,7 @@ helper method you'd like to have more control over:
 <% end %>
 >
 
-<%# app/views/form_builder/_button.html.erb %>
+<%# app/views/application/form_builder/_button.html.erb %>
 
 <button
   class="button button--primary"
@@ -76,7 +76,7 @@ You'll have local access to the `FormBuilder` instance as the template-local
 generating HTML through Rails' helpers:
 
 ```html+erb
-<%# app/views/form_builder/_email_field.html.erb %>
+<%# app/views/application/form_builder/_email_field.html.erb %>
 
 <div class="email-field-wrapper">
   <%= form.email_field(method, required: true, **options)) %>
@@ -84,7 +84,7 @@ generating HTML through Rails' helpers:
 ```
 
 ```html+erb
-<%# app/views/form_builder/_button.html.erb %>
+<%# app/views/application/form_builder/_button.html.erb %>
 
 <div class="button-wrapper">
   <%= form.button(value, options, &block) %>
@@ -149,7 +149,7 @@ and `Hash#delete`:
   <%= form.text_field(:name, class: "text-field--modifier") %>
 <% end %>
 
-<# app/views/form_builder/_text_field.html.erb %>
+<# app/views/application/form_builder/_text_field.html.erb %>
 
 <%= form.text_field(
   method,
@@ -196,7 +196,7 @@ look up path.
 
 For example, when calling `form_with(model: User.new)`, a partial declared in
 `app/views/users/form_builder/` would take precedent over a partial declared in
-`app/views/form_builder/`.
+`app/views/application/form_builder/`.
 
 ```erb
 <%# app/views/users/form_builder/_password_field.html.erb %>
@@ -241,7 +241,7 @@ additional bells and whistles.
 Declare the consumer facing inputs (in this example, `<input type="search">`):
 
 ```html+erb
-<%# app/views/form_builder/_search_field.html.erb %>
+<%# app/views/application/form_builder/_search_field.html.erb %>
 
 <%= form.search_field(
   method,
@@ -261,7 +261,7 @@ Then, declare the administrative interface's inputs, in terms of overriding the
 foundation built by the more general definitions:
 
 ```html+erb
-<%# app/views/admin/form_builder/_search_field.html.erb %>
+<%# app/views/admin/application/form_builder/_search_field.html.erb %>
 
 <%= form.search_field(
   method,
@@ -276,8 +276,8 @@ foundation built by the more general definitions:
 ) %>
 ```
 
-The rendered `admin/form_builder/search_field` partial combines options and
-arguments from both partials:
+The rendered `admin/application/form_builder/search_field` partial combines
+options and arguments from both partials:
 
 ```html
 <input
@@ -327,7 +327,7 @@ Models declared within modules will be delimited with `/`. For example,
 ### Configuration
 
 View partials lookup and resolution will be scoped to the
-`app/views/form_builder` directory.
+`app/views/application/form_builder` directory.
 
 To override this destination to another directory (for example,
 `app/views/fields`, or `app/views/users/fields`), set

--- a/lib/view_partial_form_builder/lookup_override.rb
+++ b/lib/view_partial_form_builder/lookup_override.rb
@@ -11,24 +11,12 @@ module ViewPartialFormBuilder
 
       prefixes = [
         "#{object_name}/#{view_partial_directory}",
-        object_name,
-        view_partial_directory,
         "#{root_prefix}/#{view_partial_directory}",
-        root_prefix,
       ]
 
       overridden_prefixes.reverse_each do |prefix|
-        namespace, *files = prefix.split("/")
-
-        prefixes.unshift(prefix)
-
-        if namespace.present?
-          prefixes.unshift("#{namespace}/#{view_partial_directory}")
-        end
-
         prefixes.unshift("#{prefix}/#{view_partial_directory}")
       end
-
 
       prefixes.uniq
     end

--- a/test/dummy/app/controllers/admin/application_controller.rb
+++ b/test/dummy/app/controllers/admin/application_controller.rb
@@ -1,0 +1,4 @@
+module Admin
+  class ApplicationController < ::ApplicationController
+  end
+end

--- a/test/dummy/app/controllers/admin/posts_controller.rb
+++ b/test/dummy/app/controllers/admin/posts_controller.rb
@@ -1,4 +1,4 @@
 module Admin
-  class PostsController < ApplicationController
+  class PostsController < Admin::ApplicationController
   end
 end

--- a/test/integration/admin/posts_controller_test.rb
+++ b/test/integration/admin/posts_controller_test.rb
@@ -32,7 +32,7 @@ class Admin::PostsControllerTest < ActionDispatch::IntegrationTest
     declare_template "application/form_builder/_text_field.html.erb", <<~HTML
       <input type="text" class="application-input">
     HTML
-    declare_template "admin/form_builder/_text_field.html.erb", <<~HTML
+    declare_template "admin/application/form_builder/_text_field.html.erb", <<~HTML
       <input type="text" class="admin-input" name="<%= method %>">
     HTML
 

--- a/test/integration/view_partial_form_builder_test.rb
+++ b/test/integration/view_partial_form_builder_test.rb
@@ -19,11 +19,11 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
         <%= form.text_field :name, class: "name-field" %>
       <% end %>
     HTML
-    declare_template "form_builder/_text_field.html.erb", <<~HTML
+    declare_template "application/form_builder/_text_field.html.erb", <<~HTML
       <%= form.label(method) %>
       <%= form.text_field(method, **options) %>
     HTML
-    declare_template "form_builder/_label.html.erb", <<~HTML
+    declare_template "application/form_builder/_label.html.erb", <<~HTML
       <label>Label from partial</label>
     HTML
 
@@ -42,7 +42,7 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
     declare_template "posts/_my_text_field.html.erb", <<~HTML
       <%= form.text_field :name, class: "my-partial-text-field" %>
     HTML
-    declare_template "form_builder/_text_field.html.erb", <<~'HTML'
+    declare_template "application/form_builder/_text_field.html.erb", <<~'HTML'
       <%= form.text_field(
         method,
         class: "text-field #{options.delete(:class)}",
@@ -61,7 +61,7 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
         <%= form.text_field :name %>
       <% end %>
     HTML
-    declare_template "form_builder/_text_field.html.erb", <<~HTML
+    declare_template "application/form_builder/_text_field.html.erb", <<~HTML
       <input type="text" class="application-input">
     HTML
     declare_template "posts/form_builder/_text_field.html.erb", <<~HTML
@@ -94,7 +94,7 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
         <%= form.text_field :name %>
       <% end %>
     HTML
-    declare_template "form_builder/_text_field.html.erb", <<~HTML
+    declare_template "application/form_builder/_text_field.html.erb", <<~HTML
       <input type="text" class="application-input">
     HTML
 
@@ -109,7 +109,7 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
         <%= form.text_field :name %>
       <% end %>
     HTML
-    declare_template "form_builder/_text_field.html.erb", <<~HTML
+    declare_template "application/form_builder/_text_field.html.erb", <<~HTML
       <input type="text" class="application-input">
     HTML
 
@@ -143,7 +143,7 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
     declare_template "posts/form_builder/_text_field.html.erb", <<~HTML
       <%= form.text_field(:name, class: "post-input") %>
     HTML
-    declare_template "form_builder/_label.html.erb", <<~HTML
+    declare_template "application/form_builder/_label.html.erb", <<~HTML
       <%= form.label(method, text, class: "post-label") %>
     HTML
 
@@ -192,7 +192,7 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
         <%= form.text_field :name, class: "post-input" %>
       <% end %>
     HTML
-    declare_template "form_builder/_text_field.html.erb", <<~HTML
+    declare_template "application/form_builder/_text_field.html.erb", <<~HTML
       <%= form.text_field(method, options) %>
     HTML
 
@@ -207,7 +207,7 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
         <%= form.text_field :name, value: "splat!" %>
       <% end %>
     HTML
-    declare_template "form_builder/_text_field.html.erb", <<~HTML
+    declare_template "application/form_builder/_text_field.html.erb", <<~HTML
       <%= form.text_field(method, **options) %>
     HTML
 
@@ -222,7 +222,7 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
         <%= form.default.text_field :name, class: "default-text-field" %>
       <% end %>
     HTML
-    declare_template "form_builder/_text_field.html.erb", <<~HTML
+    declare_template "application/form_builder/_text_field.html.erb", <<~HTML
       <input type="text" class="application-text-field">
     HTML
 
@@ -245,7 +245,7 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
         **options
       ) %>
     HTML
-    declare_template "form_builder/_text_field.html.erb", <<~'HTML'
+    declare_template "application/form_builder/_text_field.html.erb", <<~'HTML'
       <%= form.text_field(
         method,
         class: "text #{options.delete(:class)}",
@@ -264,10 +264,10 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
         <%= form.text_field :name, class: "text--form" %>
       <% end %>
     HTML
-    declare_template "form_builder/_text_field.html.erb", <<~'HTML'
+    declare_template "application/form_builder/_text_field.html.erb", <<~'HTML'
       <%= form.text_field(
         method,
-        partial: "form_builder/text_field",
+        partial: "application/form_builder/text_field",
         class: "text #{options.delete(:class)}",
         **options,
       ) %>
@@ -275,7 +275,7 @@ class ViewPartialFormBuilderTest < FormBuilderTestCase
     declare_template "posts/form_builder/_text_field.html.erb", <<~'HTML'
       <%= form.text_field(
         method,
-        partial: "form_builder/text_field",
+        partial: "application/form_builder/text_field",
         class: "text--post #{options.delete(:class)}",
         **options,
       ) %>
@@ -302,7 +302,7 @@ class ConfiguredViewPartialFormBuilderTest < FormBuilderTestCase
         <%= form.text_field :name %>
       <% end %>
     HTML
-    declare_template "my_forms/_text_field.html.erb", <<~HTML
+    declare_template "application/my_forms/_text_field.html.erb", <<~HTML
       <input type="text" class="my-input">
     HTML
 

--- a/test/view_partial_form_builder/button_test.rb
+++ b/test/view_partial_form_builder/button_test.rb
@@ -19,7 +19,7 @@ class ViewPartialFormBuilderButtonTest < FormBuilderTestCase
         <%= form.button("Make Post", class: "button") %>
       <% end %>
     HTML
-    declare_template "form_builder/_button.html.erb", <<~HTML
+    declare_template "application/form_builder/_button.html.erb", <<~HTML
       <% class_names = Array(options.delete(:class)) %>
 
       <%= form.button(value, class: (["my-button"] + class_names)) %>
@@ -36,7 +36,7 @@ class ViewPartialFormBuilderButtonTest < FormBuilderTestCase
         <%= form.button("Make Post") %>
       <% end %>
     HTML
-    declare_template "form_builder/_button.html.erb", <<~HTML
+    declare_template "application/form_builder/_button.html.erb", <<~HTML
       <button class="custom"><%= value %></button>
     HTML
 
@@ -51,7 +51,7 @@ class ViewPartialFormBuilderButtonTest < FormBuilderTestCase
         <%= form.button %>
       <% end %>
     HTML
-    declare_template "form_builder/_button.html.erb", <<~HTML
+    declare_template "application/form_builder/_button.html.erb", <<~HTML
       <button class="custom"><%= value %></button>
     HTML
 
@@ -69,7 +69,7 @@ class ViewPartialFormBuilderButtonTest < FormBuilderTestCase
         <%= form.button %>
       <% end %>
     HTML
-    declare_template "form_builder/_button.html.erb", <<~HTML
+    declare_template "application/form_builder/_button.html.erb", <<~HTML
       <button type="button" class="my-button"><%= value %></button>
     HTML
 

--- a/test/view_partial_form_builder/check_box_test.rb
+++ b/test/view_partial_form_builder/check_box_test.rb
@@ -19,7 +19,7 @@ class ViewPartialFormBuilderCheckBoxTest < FormBuilderTestCase
         <%= form.check_box(:published) %>
       <% end %>
     HTML
-    declare_template "form_builder/_check_box.html.erb", <<~HTML
+    declare_template "application/form_builder/_check_box.html.erb", <<~HTML
       <div class="wrapper">
         <%= form.check_box(method) %>
       </div>
@@ -36,7 +36,7 @@ class ViewPartialFormBuilderCheckBoxTest < FormBuilderTestCase
         <%= form.check_box(:name, class: "name-check_box") %>
       <% end %>
     HTML
-    declare_template "form_builder/_check_box.html.erb", <<~HTML
+    declare_template "application/form_builder/_check_box.html.erb", <<~HTML
       <% class_names = Array(options.delete(:class)) %>
 
       <%= form.check_box(method, class: ["my-checkbox"] + class_names) %>
@@ -53,7 +53,7 @@ class ViewPartialFormBuilderCheckBoxTest < FormBuilderTestCase
         <%= form.check_box(:name, {}, "true", "false") %>
       <% end %>
     HTML
-    declare_template "form_builder/_check_box.html.erb", <<~HTML
+    declare_template "application/form_builder/_check_box.html.erb", <<~HTML
       <div class="wrapper">
         <%= form.check_box(method, {}, checked_value, unchecked_value) %>
       </div>

--- a/test/view_partial_form_builder/collection_check_boxes_test.rb
+++ b/test/view_partial_form_builder/collection_check_boxes_test.rb
@@ -52,7 +52,7 @@ class ViewPartialFormBuilderCollectionCheckBoxesTest < FormBuilderTestCase
         <% end %>
       <% end %>
     HTML
-    declare_template "form_builder/_collection_check_boxes.html.erb", <<~HTML
+    declare_template "application/form_builder/_collection_check_boxes.html.erb", <<~HTML
       <%= form.collection_check_boxes(
         method,
         collection,

--- a/test/view_partial_form_builder/collection_radio_buttons_test.rb
+++ b/test/view_partial_form_builder/collection_radio_buttons_test.rb
@@ -52,7 +52,7 @@ class ViewPartialFormBuilderCollectionRadioButtonsTest < FormBuilderTestCase
         <% end %>
       <% end %>
     HTML
-    declare_template "form_builder/_collection_radio_buttons.html.erb", <<~HTML
+    declare_template "application/form_builder/_collection_radio_buttons.html.erb", <<~HTML
       <%= form.collection_radio_buttons(
         method,
         collection,

--- a/test/view_partial_form_builder/collection_select_test.rb
+++ b/test/view_partial_form_builder/collection_select_test.rb
@@ -32,7 +32,7 @@ class ViewPartialFormBuilderCollectionSelectTest < FormBuilderTestCase
       ) %>
     <% end %>
     HTML
-    declare_template "form_builder/_collection_select.html.erb", <<~HTML
+    declare_template "application/form_builder/_collection_select.html.erb", <<~HTML
       <p id="method"><%= method %></p>
       <p id="collection"><%= collection.first.post_name %></p>
       <p id="value_method"><%= value_method %></p>

--- a/test/view_partial_form_builder/date_select_test.rb
+++ b/test/view_partial_form_builder/date_select_test.rb
@@ -23,7 +23,7 @@ class ViewPartialFormBuilderDateSelectTest < FormBuilderTestCase
   end
 
   test "renders arguments as local assigns" do
-    declare_template "form_builder/_date_select.html.erb", <<~'HTML'
+    declare_template "application/form_builder/_date_select.html.erb", <<~'HTML'
       <%= form.date_select(
         method,
         options.merge(

--- a/test/view_partial_form_builder/fields_for_test.rb
+++ b/test/view_partial_form_builder/fields_for_test.rb
@@ -23,7 +23,7 @@ class FieldsForTest < FormBuilderTestCase
         <% end %>
       <% end %>
     HTML
-    declare_template "form_builder/_text_field.html.erb", <<~HTML
+    declare_template "application/form_builder/_text_field.html.erb", <<~HTML
       <p><%= method %></p>
     HTML
 
@@ -60,7 +60,7 @@ class FieldsForTest < FormBuilderTestCase
         <% end %>
       <% end %>
     HTML
-    declare_template "form_builder/_text_field.html.erb", <<~HTML
+    declare_template "application/form_builder/_text_field.html.erb", <<~HTML
       <p><%= method %></p>
     HTML
 

--- a/test/view_partial_form_builder/file_field_test.rb
+++ b/test/view_partial_form_builder/file_field_test.rb
@@ -19,7 +19,7 @@ class ViewPartialFormBuilderFileFieldTest < FormBuilderTestCase
         <%= form.file_field(:avatar) %>
       <% end %>
     HTML
-    declare_template "form_builder/_file_field.html.erb", <<~HTML
+    declare_template "application/form_builder/_file_field.html.erb", <<~HTML
       <input type="file" class="custom-file-field">
     HTML
 
@@ -34,7 +34,7 @@ class ViewPartialFormBuilderFileFieldTest < FormBuilderTestCase
         <%= form.file_field(:avatar) %>
       <% end %>
     HTML
-    declare_template "form_builder/_file_field.html.erb", <<~HTML
+    declare_template "application/form_builder/_file_field.html.erb", <<~HTML
       <input type="file">
     HTML
 

--- a/test/view_partial_form_builder/grouped_collection_select_test.rb
+++ b/test/view_partial_form_builder/grouped_collection_select_test.rb
@@ -46,7 +46,7 @@ class ViewPartialFormBuilderGroupedCollectionSelectTest < FormBuilderTestCase
       ) %>
     <% end %>
     HTML
-    declare_template "form_builder/_grouped_collection_select.html.erb", <<~HTML
+    declare_template "application/form_builder/_grouped_collection_select.html.erb", <<~HTML
       <p id="collection_count"><%= collection.count %></p>
       <p id="group_method"><%= group_method %></p>
       <p id="group_label_method"><%= group_label_method %></p>

--- a/test/view_partial_form_builder/hidden_field_test.rb
+++ b/test/view_partial_form_builder/hidden_field_test.rb
@@ -19,7 +19,7 @@ class ViewPartialFormBuilderHiddenFieldTest < FormBuilderTestCase
         <%= form.hidden_field(:name) %>
       <% end %>
     HTML
-    declare_template "form_builder/_hidden_field.html.erb", <<~HTML
+    declare_template "application/form_builder/_hidden_field.html.erb", <<~HTML
       <input type="hidden" name="<%= method %>" hidden>
     HTML
 

--- a/test/view_partial_form_builder/label_test.rb
+++ b/test/view_partial_form_builder/label_test.rb
@@ -33,7 +33,7 @@ class ViewPartialFormBuilderLabelTest < FormBuilderTestCase
         <%= form.label(:name, class: "name-label") %>
       <% end %>
     HTML
-    declare_template "form_builder/_label.html.erb", <<~HTML
+    declare_template "application/form_builder/_label.html.erb", <<~HTML
       <% class_names = Array(options.delete(:class)) %>
 
       <%= form.default.label(method, class: ["my-label"] + class_names) %>
@@ -50,7 +50,7 @@ class ViewPartialFormBuilderLabelTest < FormBuilderTestCase
         <%= form.label(:name, class: "post-label", required: true) %>
       <% end %>
     HTML
-    declare_template "form_builder/_label.html.erb", <<~HTML
+    declare_template "application/form_builder/_label.html.erb", <<~HTML
       <% required = options.delete(:required) %>
 
       <%= form.label(method, options) %>
@@ -73,7 +73,7 @@ class ViewPartialFormBuilderLabelTest < FormBuilderTestCase
         <% end %>
       <% end %>
     HTML
-    declare_template "form_builder/_label.html.erb", <<~HTML
+    declare_template "application/form_builder/_label.html.erb", <<~HTML
       <%= form.label(method, &block) %>
     HTML
 
@@ -90,7 +90,7 @@ class ViewPartialFormBuilderLabelTest < FormBuilderTestCase
         <% end %>
       <% end %>
     HTML
-    declare_template "form_builder/_label.html.erb", <<~HTML
+    declare_template "application/form_builder/_label.html.erb", <<~HTML
       <%= form.label(method, **options, &block) %>
     HTML
 

--- a/test/view_partial_form_builder/lookup_override_test.rb
+++ b/test/view_partial_form_builder/lookup_override_test.rb
@@ -13,12 +13,12 @@ module ViewPartialFormBuilder
 
       *rest, root = lookup_context.prefixes
 
-      assert_equal "application", root
-      assert_includes rest, "posts"
+      assert_equal "application/forms", root
+      assert_includes rest, "posts/forms"
     end
 
     test "#prefixes ensures the list of prefixes descends in specificity" do
-      prefixes =["admin/users", "users", "application"]
+      prefixes = ["admin/users", "admin/application", "users", "application"]
       lookup_context = LookupOverride.new(
         prefixes: prefixes,
         object_name: "user",
@@ -28,13 +28,9 @@ module ViewPartialFormBuilder
       assert_equal(
         [
           "admin/users/form_builder",
-          "admin/form_builder",
-          "admin/users",
+          "admin/application/form_builder",
           "users/form_builder",
-          "users",
-          "form_builder",
           "application/form_builder",
-          "application",
         ],
         lookup_context.prefixes,
       )

--- a/test/view_partial_form_builder/radio_button_test.rb
+++ b/test/view_partial_form_builder/radio_button_test.rb
@@ -19,7 +19,7 @@ class ViewPartialFormBuilderRadioButtonTest < FormBuilderTestCase
         <%= form.radio_button(:name, "New", class: "name-radio_button") %>
       <% end %>
     HTML
-    declare_template "form_builder/_radio_button.html.erb", <<~HTML
+    declare_template "application/form_builder/_radio_button.html.erb", <<~HTML
       <% class_names = Array(options.delete(:class)) %>
 
       <%= form.radio_button(method, tag_value, class: ["my-radio"] + class_names) %>
@@ -37,7 +37,7 @@ class ViewPartialFormBuilderRadioButtonTest < FormBuilderTestCase
         <%= form.radio_button(:name, "Old") %>
       <% end %>
     HTML
-    declare_template "form_builder/_radio_button.html.erb", <<~HTML
+    declare_template "application/form_builder/_radio_button.html.erb", <<~HTML
       <div class="wrapper">
         <%= form.radio_button(method, tag_value) %>
       </div>

--- a/test/view_partial_form_builder/rich_text_area_test.rb
+++ b/test/view_partial_form_builder/rich_text_area_test.rb
@@ -25,7 +25,7 @@ class ViewPartialFormBuilderRichTextAreaTest < FormBuilderTestCase
         <%= form.rich_text_area(:avatar) %>
       <% end %>
     HTML
-    declare_template "form_builder/_rich_text_area.html.erb", <<~HTML
+    declare_template "application/form_builder/_rich_text_area.html.erb", <<~HTML
       <div class="wrapper">
         <%= form.rich_text_area(method, options) %>
       </div>

--- a/test/view_partial_form_builder/select_test.rb
+++ b/test/view_partial_form_builder/select_test.rb
@@ -39,7 +39,7 @@ class ViewPartialFormBuilderSelectTest < FormBuilderTestCase
       ) %>
     <% end %>
     HTML
-    declare_template "form_builder/_select.html.erb", <<~HTML
+    declare_template "application/form_builder/_select.html.erb", <<~HTML
       <p id="method"><%= method %></p>
       <p id="choices"><%= choices.to_json %></p>
       <p id="options"><%= options.to_json %></p>
@@ -63,7 +63,7 @@ class ViewPartialFormBuilderSelectTest < FormBuilderTestCase
       <% end %>
     <% end %>
     HTML
-    declare_template "form_builder/_select.html.erb", <<~HTML
+    declare_template "application/form_builder/_select.html.erb", <<~HTML
       <%= form.select(method) do %>
         <%= yield %>
       <% end %>
@@ -87,7 +87,7 @@ class ViewPartialFormBuilderSelectTest < FormBuilderTestCase
       ) %>
     <% end %>
     HTML
-    declare_template "form_builder/_select.html.erb", <<~'HTML'
+    declare_template "application/form_builder/_select.html.erb", <<~'HTML'
       <%= form.select(
         method,
         choices,

--- a/test/view_partial_form_builder/submit_test.rb
+++ b/test/view_partial_form_builder/submit_test.rb
@@ -19,7 +19,7 @@ class ViewPartialFormBuilderSubmitTest < FormBuilderTestCase
         <%= form.submit("Make Post", class: "my-submit") %>
       <% end %>
     HTML
-    declare_template "form_builder/_submit.html.erb", <<~'HTML'
+    declare_template "application/form_builder/_submit.html.erb", <<~'HTML'
       <%= form.default.submit(
         value,
         class: "submit #{options.delete(:class)}",
@@ -38,7 +38,7 @@ class ViewPartialFormBuilderSubmitTest < FormBuilderTestCase
         <%= form.submit("Make Post") %>
       <% end %>
     HTML
-    declare_template "form_builder/_submit.html.erb", <<~HTML
+    declare_template "application/form_builder/_submit.html.erb", <<~HTML
       <button type="submit" class="my-button"><%= value %></button>
     HTML
 
@@ -53,7 +53,7 @@ class ViewPartialFormBuilderSubmitTest < FormBuilderTestCase
         <%= form.submit %>
       <% end %>
     HTML
-    declare_template "form_builder/_submit.html.erb", <<~HTML
+    declare_template "application/form_builder/_submit.html.erb", <<~HTML
       <button type="submit" class="my-button"><%= value %></button>
     HTML
 
@@ -71,7 +71,7 @@ class ViewPartialFormBuilderSubmitTest < FormBuilderTestCase
         <%= form.submit %>
       <% end %>
     HTML
-    declare_template "form_builder/_submit.html.erb", <<~HTML
+    declare_template "application/form_builder/_submit.html.erb", <<~HTML
       <button type="submit" class="my-button"><%= value %></button>
     HTML
 

--- a/test/view_partial_form_builder/time_zone_select_test.rb
+++ b/test/view_partial_form_builder/time_zone_select_test.rb
@@ -24,7 +24,7 @@ class ViewPartialFormBuilderTimeZoneSelectTest < FormBuilderTestCase
       ) %>
     <% end %>
     HTML
-    declare_template "form_builder/_time_zone_select.html.erb", <<~HTML
+    declare_template "application/form_builder/_time_zone_select.html.erb", <<~HTML
       <p id="method"><%= method %></p>
       <p id="priority_zones"><%= priority_zones.first %></p>
       <p id="options"><%= options.to_json %></p>


### PR DESCRIPTION
During controller-based rendering, the prefixes are most likely to
contain an `application/` directory, since most controllers inherit from
`ApplicationController`.

This change intends to fit within that structure.