### PR TITLE
Use Zeitwerk for file loading

### DIFF
--- a/lib/view_partial_form_builder.rb
+++ b/lib/view_partial_form_builder.rb
@@ -1,5 +1,9 @@
-require "view_partial_form_builder/engine"
+require "zeitwerk"
+loader = Zeitwerk::Loader.for_gem
+loader.setup
 
 module ViewPartialFormBuilder
   mattr_accessor :view_partial_directory, default: "form_builder"
 end
+
+loader.eager_load

--- a/lib/view_partial_form_builder/engine.rb
+++ b/lib/view_partial_form_builder/engine.rb
@@ -1,5 +1,3 @@
-require "view_partial_form_builder/form_builder"
-
 module ViewPartialFormBuilder
   class Engine < ::Rails::Engine
     ActiveSupport.on_load(:action_controller_base) do

--- a/lib/view_partial_form_builder/form_builder.rb
+++ b/lib/view_partial_form_builder/form_builder.rb
@@ -1,5 +1,3 @@
-require "view_partial_form_builder/lookup_override"
-
 module ViewPartialFormBuilder
   class FormBuilder < ActionView::Helpers::FormBuilder
     attr_reader :default

--- a/view_partial_form_builder.gemspec
+++ b/view_partial_form_builder.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "actionview", ">= 4.0.0"
   spec.add_dependency "railties", ">= 4.0.0"
+  spec.add_dependency "zeitwerk", ">= 2.4.0"
 
   spec.add_development_dependency "minitest-around"
   spec.add_development_dependency "activemodel", ">= 4.0.0"


### PR DESCRIPTION
According to its documentation:

> Zeitwerk is an efficient and thread-safe code loader for Ruby.

> Given a conventional file structure, Zeitwerk is able to load your
> project's classes and modules on demand (autoloading), or upfront
> (eager loading). You don't need to write require calls for your own
> files, rather, you can streamline your programming knowing that your
> classes and modules are available everywhere. This feature is
> efficient, thread-safe, and matches Ruby's semantics for constants.

Specifically, this commit creates a loader using
[Zeitwerk::Loader.for_gem][for_gem].

[for_gem]: https://github.com/fxn/zeitwerk/tree/v2.4.0#for_gem