### PR TITLE
Improve test coverage of intended behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Declare the consumer facing inputs (in this example, `<input type="search">`):
   method,
   class: "
     search-field
-    #{options.delete(:class}
+    #{options.delete(:class)}
   ",
   "data-controller": "
     input->search#executeQuery

--- a/test/view_partial_form_builder/collection_check_boxes_test.rb
+++ b/test/view_partial_form_builder/collection_check_boxes_test.rb
@@ -2,56 +2,37 @@ require "form_builder_test_case"
 
 class ViewPartialFormBuilderCollectionCheckBoxesTest < FormBuilderTestCase
   test "renders defaults when overrides are not declared" do
-    choices = [
-      OpenStruct.new(post_id: "1", post_name: "one"),
-    ]
-    declare_template "application/_form.html.erb", <<~HTML
-    <%= form_with(model: Post.new) do |form| %>
-      <%= form.collection_check_boxes(:name, choices, :post_id, :post_name) %>
-    <% end %>
+    choice = OpenStruct.new(post_id: "1", post_name: "one")
+
+    render(locals: {choices: [choice]}, inline: <<~HTML)
+      <%= form_with(model: Post.new) do |form| %>
+        <%= form.collection_check_boxes(:name, choices, :post_id, :post_name) %>
+      <% end %>
     HTML
 
-    render(partial: "application/form", locals: { choices: choices })
-
-    assert_select %(input[type="checkbox"][value="1"])
-    assert_select("label", text: "one")
+    assert_select %(input[type="checkbox"]), value: choice.post_id
+    assert_select "label", text: choice.post_name
   end
 
   test "renders defaults when overrides are not declared and a block is given" do
-    choices = [
-      OpenStruct.new(post_id: "1", post_name: "one"),
-    ]
-    declare_template "application/_form.html.erb", <<~HTML
-    <%= form_with(model: Post.new) do |form| %>
-      <%= form.collection_check_boxes(:name, choices, :post_id, :post_name) do %>
-        Hello, From Block
-      <% end %>
-    <% end %>
-    HTML
+    choice = OpenStruct.new(post_id: "1", post_name: "one")
 
-    render(partial: "application/form", locals: { choices: choices })
-
-    assert_select("form", text: "Hello, From Block")
-  end
-
-  test "makes arguments available as local assigns" do
-    choices = [
-      OpenStruct.new(post_id: "1", post_name: "one"),
-    ]
-    declare_template "application/_form.html.erb", <<~HTML
+    render(locals: {choices: [choice]}, inline: <<~HTML)
       <%= form_with(model: Post.new) do |form| %>
-        <%= form.collection_check_boxes(
-          :name,
-          choices,
-          :post_id,
-          :post_name,
-          "data-attr": "foo",
-        ) do |builder| %>
-          <%= builder.label(class: "checkbox-label") %>
-          <%= builder.check_box(class: "checkbox-input") %>
+        <%= form.collection_check_boxes(:name, choices, :post_id, :post_name) do |builder| %>
+          <span id="block-text">Hello, From Block</span>
+          <%= builder.label %>
+          <%= builder.check_box %>
         <% end %>
       <% end %>
     HTML
+
+    assert_select "#block-text", text: "Hello, From Block"
+    assert_select %(input[type="checkbox"]), value: choice.post_id
+    assert_select "label", text: choice.post_name
+  end
+
+  test "makes arguments available as local assigns" do
     declare_template "application/form_builder/_collection_check_boxes.html.erb", <<~HTML
       <%= form.collection_check_boxes(
         method,
@@ -59,14 +40,28 @@ class ViewPartialFormBuilderCollectionCheckBoxesTest < FormBuilderTestCase
         value_method,
         text_method,
         options,
-        html_options,
+        "data-attr": "foo",
+        **html_options,
         &block
       ) %>
     HTML
+    choice = OpenStruct.new(post_id: "1", post_name: "one")
 
-    render(partial: "application/form", locals: { choices: choices })
+    render(locals: {choices: [choice]}, inline: <<~HTML)
+      <%= form_with(model: Post.new) do |form| %>
+        <%= form.collection_check_boxes(
+          :name,
+          choices,
+          :post_id,
+          :post_name,
+        ) do |builder| %>
+          <%= builder.label(class: "checkbox-label") %>
+          <%= builder.check_box(class: "checkbox-input") %>
+        <% end %>
+      <% end %>
+    HTML
 
-    assert_select %(input[type="checkbox"][class="checkbox-input"][data-attr="foo"]), value: "1"
-    assert_select %(label[class="checkbox-label"]), text: "one"
+    assert_select %(input[type="checkbox"][class="checkbox-input"][data-attr="foo"]), value: choice.post_id
+    assert_select %(label[class="checkbox-label"]), text: choice.post_name
   end
 end

--- a/test/view_partial_form_builder/collection_radio_buttons_test.rb
+++ b/test/view_partial_form_builder/collection_radio_buttons_test.rb
@@ -2,71 +2,64 @@ require "form_builder_test_case"
 
 class ViewPartialFormBuilderCollectionRadioButtonsTest < FormBuilderTestCase
   test "renders defaults when overrides are not declared" do
-    choices = [
-      OpenStruct.new(post_id: "1", post_name: "one"),
-    ]
-    declare_template "application/_form.html.erb", <<~HTML
-    <%= form_with(model: Post.new) do |form| %>
-      <%= form.collection_radio_buttons(:name, choices, :post_id, :post_name) %>
-    <% end %>
+    choice = OpenStruct.new(post_id: "1", post_name: "one")
+
+    render(locals: {choices: [choice]}, inline: <<~HTML)
+      <%= form_with(model: Post.new) do |form| %>
+        <%= form.collection_radio_buttons(:name, choices, :post_id, :post_name) %>
+      <% end %>
     HTML
 
-    render(partial: "application/form", locals: { choices: choices })
-
-    assert_select %(input[type="radio"][value="1"])
-    assert_select "label", text: "one"
+    assert_select %(input[type="radio"]), value: choice.post_id
+    assert_select "label", text: choice.post_name
   end
 
   test "renders defaults when overrides are not declared and a block is given" do
-    choices = [
-      OpenStruct.new(post_id: "1", post_name: "one"),
-    ]
-    declare_template "application/_form.html.erb", <<~HTML
-    <%= form_with(model: Post.new) do |form| %>
-      <%= form.collection_radio_buttons(:name, choices, :post_id, :post_name) do %>
-        Hello, From Block
+    choice = OpenStruct.new(post_id: "1", post_name: "one")
+
+    render(locals: {choices: [choice]}, inline: <<~HTML)
+      <%= form_with(model: Post.new) do |form| %>
+        <%= form.collection_radio_buttons(:name, choices, :post_id, :post_name) do |builder| %>
+          <span id="extra-text">Hello, From Block</span>
+          <%= builder.label %>
+          <%= builder.radio_button %>
+        <% end %>
       <% end %>
-    <% end %>
     HTML
 
-    render(partial: "application/form", locals: { choices: choices })
-
-    assert_select("form", text: "Hello, From Block")
+    assert_select "#extra-text", text: "Hello, From Block"
+    assert_select %(input[type="radio"]), value: choice.post_id
+    assert_select "label", text: choice.post_name
   end
 
   test "makes arguments available as local assigns" do
-    choices = [
-      OpenStruct.new(post_id: "1", post_name: "one"),
-    ]
-    declare_template "application/_form.html.erb", <<~HTML
+    declare_template "form_builder/_collection_radio_buttons.html.erb", <<~HTML
+      <%= form.collection_radio_buttons(
+        method,
+        collection,
+        value_method,
+        text_method,
+        "data-attr": "foo",
+        **html_options,
+      ) do |builder| %>
+        <%= builder.label(class: "radio-label") %>
+        <%= builder.radio_button(class: "radio-input") %>
+      <% end %>
+    HTML
+    choice = OpenStruct.new(post_id: "1", post_name: "one")
+
+    render(locals: {choices: [choice]}, inline: <<~HTML)
       <%= form_with(model: Post.new) do |form| %>
         <%= form.collection_radio_buttons(
           :name,
           choices,
           :post_id,
           :post_name,
-          "data-attr": "foo",
-        ) do |builder| %>
-          <%= builder.label(class: "radio-label") %>
-          <%= builder.radio_button(class: "radio-input") %>
-        <% end %>
+        ) %>
       <% end %>
     HTML
-    declare_template "application/form_builder/_collection_radio_buttons.html.erb", <<~HTML
-      <%= form.collection_radio_buttons(
-        method,
-        collection,
-        value_method,
-        text_method,
-        options,
-        html_options,
-        &block
-      ) %>
-    HTML
 
-    render(partial: "application/form", locals: { choices: choices })
-
-    assert_select %(input[type="radio"][class="radio-input"][data-attr="foo"]), value: "1"
-    assert_select %(label[class="radio-label"]), text: "one"
+    assert_select %(input[type="radio"]), value: choice.post_id
+    assert_select "label", text: choice.post_name
   end
 end

--- a/test/view_partial_form_builder/collection_select_test.rb
+++ b/test/view_partial_form_builder/collection_select_test.rb
@@ -2,52 +2,41 @@ require "form_builder_test_case"
 
 class ViewPartialFormBuilderCollectionSelectTest < FormBuilderTestCase
   test "renders defaults when overrides are not declared" do
-    choices = [
-      OpenStruct.new(post_id: "1", post_name: "one"),
-    ]
-    declare_template "application/_form.html.erb", <<~HTML
-    <%= form_with(model: Post.new) do |form| %>
-      <%= form.collection_select(:name, choices, :post_id, :post_name) %>
-    <% end %>
+    choice = OpenStruct.new(text: "Option", value: "value")
+
+    render(inline: <<~HTML, locals:{choices: [choice]})
+      <%= form_with(model: Post.new) do |form| %>
+        <%= form.collection_select(:name, choices, :value, :text) %>
+      <% end %>
     HTML
 
-    render(partial: "application/form", locals: { choices: choices })
-
-    assert_select %(option[value="1"]), text: "one"
+    assert_select %(option[value="#{choice.value}"]), text: choice.text
   end
 
   test "makes arguments available as local assigns" do
-    choices = [
-      OpenStruct.new(post_id: "1", post_name: "one"),
-    ]
-    declare_template "application/_form.html.erb", <<~HTML
-    <%= form_with(model: Post.new) do |form| %>
-      <%= form.collection_select(
-        :name,
-        choices,
-        :post_id,
-        :post_name,
-        { prompt: true },
-        "data-attr": "foo",
-      ) %>
-    <% end %>
+    declare_template "application/form_builder/_select.html.erb", <<~HTML
+      <%= form_with(model: Post.new) do |form| %>
+        <%= form.collection_select(
+          method,
+          choices,
+          :value,
+          :text,
+          { prompt: true },
+          "data-attr": "foo",
+        ) %>
+      <% end %>
     HTML
-    declare_template "application/form_builder/_collection_select.html.erb", <<~HTML
-      <p id="method"><%= method %></p>
-      <p id="collection"><%= collection.first.post_name %></p>
-      <p id="value_method"><%= value_method %></p>
-      <p id="text_method"><%= text_method %></p>
-      <p id="options"><%= options.to_json %></p>
-      <p id="html_options"><%= html_options.to_json %></p>
+    choice = OpenStruct.new(text: "one", value: "1")
+
+    render(locals: {choices: [choice]}, inline: <<~HTML)
+      <%= form_with(model: Post.new) do |form| %>
+        <%= form.select(:name, choices) %>
+      <% end %>
     HTML
 
-    render(partial: "application/form", locals: { choices: choices })
-
-    assert_select "#method", text: "name"
-    assert_select "#collection", text: "one"
-    assert_select "#value_method", text: "post_id"
-    assert_select "#text_method", text: "post_name"
-    assert_select "#options", text: { prompt: true }.to_json
-    assert_select "#html_options", text: { "data-attr": "foo" }.to_json
+    assert_select %(select[data-attr="foo"]) do
+      assert_select %(option[value=""]), count: 1
+      assert_select %(option[value="#{choice.last}"]), text: choice.first, count: 1
+    end
   end
 end

--- a/test/view_partial_form_builder/grouped_collection_select_test.rb
+++ b/test/view_partial_form_builder/grouped_collection_select_test.rb
@@ -2,68 +2,56 @@ require "form_builder_test_case"
 
 class ViewPartialFormBuilderGroupedCollectionSelectTest < FormBuilderTestCase
   test "renders defaults when overrides are not declared" do
-    groups = [
-      OpenStruct.new(group_name: "group 1", posts: [
-        OpenStruct.new(post_id: "1", post_name: "one"),
-      ]),
-    ]
-    declare_template "application/_form.html.erb", <<~HTML
-    <%= form_with(model: Post.new) do |form| %>
-      <%= form.grouped_collection_select(
-        :name,
-        groups,
-        :posts,
-        :group_name,
-        :post_id,
-        :post_name,
-      ) %>
-    <% end %>
+    post = OpenStruct.new(post_id: "1", post_name: "one")
+    group = OpenStruct.new(group_name: "group 1", posts: [post])
+
+    render(locals: {groups: [group]}, inline: <<~HTML)
+      <%= form_with(model: Post.new) do |form| %>
+        <%= form.grouped_collection_select(
+          :name,
+          groups,
+          :posts,
+          :group_name,
+          :post_id,
+          :post_name,
+        ) %>
+      <% end %>
     HTML
 
-    render(partial: "application/form", locals: { groups: groups })
-
-    assert_select %(optgroup[label="group 1"])
-    assert_select %(option[value="1"]), text: "one"
+    assert_select %(optgroup[label="#{group.group_name}"])
+    assert_select %(option), value: post.post_id, text: post.post_name
   end
 
   test "renders arguments as local assigns" do
-    groups = [
-      OpenStruct.new(group_name: "group 1", posts: [
-        OpenStruct.new(post_id: "1", post_name: "one"),
-      ]),
-    ]
-    declare_template "application/_form.html.erb", <<~HTML
-    <%= form_with(model: Post.new) do |form| %>
+    declare_template "application/form_builder/_grouped_collection_select.html.erb", <<~HTML
       <%= form.grouped_collection_select(
-        :name,
-        groups,
-        :posts,
-        :group_name,
-        :post_id,
-        :post_name,
+        method,
+        collection,
+        group_method,
+        group_label_method,
+        option_key_method,
+        option_value_method,
         { prompt: true },
         { "data-attr": "foo" },
       ) %>
-    <% end %>
     HTML
-    declare_template "application/form_builder/_grouped_collection_select.html.erb", <<~HTML
-      <p id="collection_count"><%= collection.count %></p>
-      <p id="group_method"><%= group_method %></p>
-      <p id="group_label_method"><%= group_label_method %></p>
-      <p id="option_key_method"><%= option_key_method %></p>
-      <p id="option_value_method"><%= option_value_method %></p>
-      <p id="options"><%= options.to_json %></p>
-      <p id="html_options"><%= html_options.to_json %></p>
+    post = OpenStruct.new(post_id: "1", post_name: "one")
+    group = OpenStruct.new(group_name: "group 1", posts: [post])
+
+    render(locals: {groups: [group]}, inline: <<~HTML)
+      <%= form_with(model: Post.new) do |form| %>
+        <%= form.grouped_collection_select(
+          :name,
+          groups,
+          :posts,
+          :group_name,
+          :post_id,
+          :post_name,
+        ) %>
+      <% end %>
     HTML
 
-    render(partial: "application/form", locals: { groups: groups })
-
-    assert_select "#collection_count", text: "1"
-    assert_select "#group_method", text: "posts"
-    assert_select "#group_label_method", text: "group_name"
-    assert_select "#option_key_method", text: "post_id"
-    assert_select "#option_value_method", text: "post_name"
-    assert_select "#options", text: { prompt: true }.to_json
-    assert_select "#html_options", text: { "data-attr": "foo" }.to_json
+    assert_select %(optgroup[label="#{group.group_name}"])
+    assert_select %(option), value: group.post_id, text: group.post_name
   end
 end

--- a/test/view_partial_form_builder/select_test.rb
+++ b/test/view_partial_form_builder/select_test.rb
@@ -2,106 +2,79 @@ require "form_builder_test_case"
 
 class ViewPartialFormBuilderSelectTest < FormBuilderTestCase
   test "renders defaults when overrides are not declared" do
-    declare_template "application/_form.html.erb", <<~HTML
+    render(inline: <<~HTML)
       <%= form_with(model: Post.new) do |form| %>
         <%= form.select(:name, [["Option", "value"]]) %>
       <% end %>
     HTML
 
-    render(partial: "application/form")
-
     assert_select %(option[value="value"]), text: "Option"
   end
 
   test "renders defaults with block when overrides are not declared" do
-    declare_template "application/_form.html.erb", <<~HTML
+    render(inline: <<~HTML)
       <%= form_with(model: Post.new) do |form| %>
-        <%= form.select(:name, [["Option", "value"]]) do %>
-          <p>block value</p>
+        <%= form.select(:name) do %>
+          <option value="value">Option</option>
         <% end %>
       <% end %>
     HTML
 
-    render(partial: "application/form")
-
-    assert_select "p", text: "block value"
+    assert_select %(option[value="value"]), text: "Option"
   end
 
   test "makes arguments available as local assigns without block" do
-    choices = [ "one", "1" ]
-    declare_template "application/_form.html.erb", <<~HTML
-    <%= form_with(model: Post.new) do |form| %>
-      <%= form.select(
-        :name,
-        choices,
-        { prompt: true },
-        "data-attr": "foo",
-      ) %>
-    <% end %>
-    HTML
     declare_template "application/form_builder/_select.html.erb", <<~HTML
-      <p id="method"><%= method %></p>
-      <p id="choices"><%= choices.to_json %></p>
-      <p id="options"><%= options.to_json %></p>
-      <p id="html_options"><%= html_options.to_json %></p>
+      <%= form_with(model: Post.new) do |form| %>
+        <%= form.select(
+          method,
+          choices,
+          { prompt: true },
+          "data-attr": "foo",
+        ) %>
+      <% end %>
+    HTML
+    choice = ["one", "1"]
+
+    render(locals: {choices: [choice]}, inline: <<~HTML)
+      <%= form_with(model: Post.new) do |form| %>
+        <%= form.select(:name, choices) %>
+      <% end %>
     HTML
 
-    render(partial: "application/form", locals: { choices: choices })
-
-    assert_select "#method", text: "name"
-    assert_select "#choices", text: choices.to_json
-    assert_select "#options", text: { prompt: true }.to_json
-    assert_select "#html_options", text: { "data-attr": "foo" }.to_json
+    assert_select %(select[data-attr="foo"]) do
+      assert_select %(option[value=""]), count: 1
+      assert_select %(option[value="#{choice.last}"]), text: choice.first, count: 1
+    end
   end
 
   test "makes arguments available as local assigns with block" do
-    choices = [ "one", "1" ]
-    declare_template "application/_form.html.erb", <<~HTML
-    <%= form_with(model: Post.new) do |form| %>
-      <%= form.select(:name) do %>
-        <option value="first">First</option>
-      <% end %>
-    <% end %>
-    HTML
     declare_template "application/form_builder/_select.html.erb", <<~HTML
-      <%= form.select(method) do %>
-        <%= yield %>
+      <%= form_with(model: Post.new) do |form| %>
+        <%= form.select(
+          method,
+          choices,
+          "data-attr": "foo",
+          &block
+        ) %>
+      <% end %>
+    HTML
+    choice = ["one", "1"]
+
+    render(locals: {choices: [choice]}, inline: <<~HTML)
+      <%= form_with(model: Post.new) do |form| %>
+        <%= form.select(:name) do %>
+          <option value="">Pick a thing</option>
+          <% choices.each do |text, value| %>
+            <option value="<%= value %>"><%= text %></option>
+          <% end %>
+        <% end %>
       <% end %>
     HTML
 
-    render(partial: "application/form", locals: { choices: choices })
-
-    assert_select %(option[value="first"]), text: "First", count: 1
-    assert_select %(select[name="post[name]"])
-  end
-
-  test "can pass through argument, html_options, and block parameters" do
-    choices = [ "one", "1" ]
-    declare_template "application/_form.html.erb", <<~HTML
-    <%= form_with(model: Post.new) do |form| %>
-      <%= form.select(
-        :name,
-        [ ["First", "first"] ],
-        { prompt: "Please select" },
-        class: "select--modifier",
-      ) %>
-    <% end %>
-    HTML
-    declare_template "application/form_builder/_select.html.erb", <<~'HTML'
-      <%= form.select(
-        method,
-        choices,
-        options,
-        class: "select #{html_options.delete(:class)}",
-        **html_options,
-        &block
-      ) %>
-    HTML
-
-    render(partial: "application/form", locals: { choices: choices })
-
-    assert_select %(option[value=""]), text: "Please select", count: 1
-    assert_select %(option[value="first"]), text: "First", count: 1
-    assert_select %(select[name="post[name]"][class="select select--modifier"])
+    assert_select %(select[data-attr="foo"]) do
+      assert_select %(option[value=""]), text: "Pick a thing", count: 1
+      assert_select %(option[value="#{choice.last}"]), text: choice.first, count: 1
+    end
   end
 end

--- a/test/view_partial_form_builder/submit_test.rb
+++ b/test/view_partial_form_builder/submit_test.rb
@@ -20,7 +20,7 @@ class ViewPartialFormBuilderSubmitTest < FormBuilderTestCase
       <% end %>
     HTML
     declare_template "application/form_builder/_submit.html.erb", <<~'HTML'
-      <%= form.default.submit(
+      <%= form.submit(
         value,
         class: "submit #{options.delete(:class)}",
         **options,
@@ -29,7 +29,7 @@ class ViewPartialFormBuilderSubmitTest < FormBuilderTestCase
 
     render(partial: "application/form")
 
-    assert_select %([type="submit"][value="Make Post"][class="submit my-submit"])
+    assert_select %([type="submit"][class="submit my-submit"]), value: "Make Post"
   end
 
   test "makes `value` available" do
@@ -39,12 +39,12 @@ class ViewPartialFormBuilderSubmitTest < FormBuilderTestCase
       <% end %>
     HTML
     declare_template "application/form_builder/_submit.html.erb", <<~HTML
-      <button type="submit" class="my-button"><%= value %></button>
+      <input type="submit" class="my-button" value="<%= value %>">
     HTML
 
     render(partial: "application/form")
 
-    assert_select("button.my-button", text: "Make Post")
+    assert_select("input.my-button", value: "Make Post")
   end
 
   test "makes `value` available when not passed" do
@@ -54,12 +54,12 @@ class ViewPartialFormBuilderSubmitTest < FormBuilderTestCase
       <% end %>
     HTML
     declare_template "application/form_builder/_submit.html.erb", <<~HTML
-      <button type="submit" class="my-button"><%= value %></button>
+      <input type="submit" class="my-button" value="<%= value %>">
     HTML
 
     render(partial: "application/form")
 
-    assert_select("button", text: "Create Post")
+    assert_select("input", value: "Create Post")
   end
 
   test "makes internationalized `value` when not passed" do
@@ -72,11 +72,11 @@ class ViewPartialFormBuilderSubmitTest < FormBuilderTestCase
       <% end %>
     HTML
     declare_template "application/form_builder/_submit.html.erb", <<~HTML
-      <button type="submit" class="my-button"><%= value %></button>
+      <input type="submit" class="my-button" value="<%= value %>">
     HTML
 
     render(partial: "application/form")
 
-    assert_select("button.my-button", text: "Make Post")
+    assert_select("input.my-button", value: "Make Post")
   end
 end

--- a/test/view_partial_form_builder/time_zone_select_test.rb
+++ b/test/view_partial_form_builder/time_zone_select_test.rb
@@ -3,39 +3,40 @@ require "form_builder_test_case"
 class ViewPartialFormBuilderTimeZoneSelectTest < FormBuilderTestCase
   test "renders defaults when overrides are not declared" do
     declare_template "application/_form.html.erb", <<~HTML
-    <%= form_with(model: Post.new) do |form| %>
-      <%= form.time_zone_select(:name, ActiveSupport::TimeZone.us_zones) %>
-    <% end %>
     HTML
 
-    render(partial: "application/form")
+    render(inline: <<~HTML)
+      <%= form_with(model: Post.new) do |form| %>
+        <%= form.time_zone_select(:name, ActiveSupport::TimeZone.us_zones, {prompt: true}) %>
+      <% end %>
+    HTML
 
-    assert_select %(option[value="America/Adak"]), text: "(GMT-10:00) America/Adak"
+    assert_select %(select[name="post[name]"]) do
+      assert_select %(option[value=""])
+      assert_select %(option[value="America/Adak"]), text: "(GMT-10:00) America/Adak", count: 1
+    end
   end
 
   test "renders arguments as local assigns" do
-    declare_template "application/_form.html.erb", <<~HTML
-    <%= form_with(model: Post.new) do |form| %>
-      <%= form.time_zone_select(
-        :name,
-        ActiveSupport::TimeZone.us_zones,
-        { prompt: true },
-        "data-attr": "foo",
-      ) %>
-    <% end %>
-    HTML
     declare_template "application/form_builder/_time_zone_select.html.erb", <<~HTML
-      <p id="method"><%= method %></p>
-      <p id="priority_zones"><%= priority_zones.first %></p>
-      <p id="options"><%= options.to_json %></p>
-      <p id="html_options"><%= html_options.to_json %></p>
+      <%= form.time_zone_select(
+        method,
+        priority_zones,
+        options.merge(prompt: true),
+        "data-attr": "foo",
+        **html_options
+      ) %>
     HTML
 
-    render(partial: "application/form")
+    render(inline: <<~HTML)
+      <%= form_with(model: Post.new) do |form| %>
+        <%= form.time_zone_select(:name, ActiveSupport::TimeZone.us_zones) %>
+      <% end %>
+    HTML
 
-    assert_select "#method", text: "name"
-    assert_select "#priority_zones", text: "(GMT-10:00) America/Adak"
-    assert_select "#options", text: { prompt: true }.to_json
-    assert_select "#html_options", text: { "data-attr": "foo" }.to_json
+    assert_select %(select[data-attr="foo"][name="post[name]"]) do
+      assert_select %(option[value=""])
+      assert_select %(option[value="America/Adak"]), text: "(GMT-10:00) America/Adak", count: 1
+    end
   end
 end


### PR DESCRIPTION
These changes more accurately exercise the _behavior_ of the helpers
they cover.

For example, prior to this commit, most `collection_`-prefixed helpers
were testing that the variables themselves were made available to the
partial.

While valuable, that doesn't accurately cover that the
`ViewPartialFormBuilder` constructs the resulting HTML to match the
behavior of the default `FormBuilder`.

Testing structure changes
---

In addition to writing better assertions, this commit moves the
`form_with` calls from in-test templates to the [Exercise Phase][] of
the test by passing the ERB template directly the the [`render` call as
the `inline:` option][render].

[Exercise Phase]: https://thoughtbot.com/blog/four-phase-test
[render]: https://api.rubyonrails.org/classes/ActionController/Renderer.html#method-i-render