### PR TITLE
Expand Continuous Integration Matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7"]
-        rails: ["5.2", "6.0", "master"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        rails: ["6.0", "6.1", "7.0"]
+        include:
+          - ruby: "2.7"
+            rails: "5.2"
 
     env:
       RAILS_VERSION: "${{ matrix.rails }}"
@@ -23,6 +26,7 @@ jobs:
     - name: "Install Ruby ${{ matrix.ruby }}"
       uses: "ruby/setup-ruby@v1"
       with:
+        rubygems: 3.3.13
         ruby-version: "${{ matrix.ruby }}"
 
     - name: "Generate lockfile"

--- a/Gemfile
+++ b/Gemfile
@@ -14,12 +14,20 @@ gemspec
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
 
-rails_version = ENV.fetch("RAILS_VERSION", "6.0")
+rails_version = ENV.fetch("RAILS_VERSION", "7.0")
 
-if rails_version == "master"
-  rails_constraint = { github: "rails/rails" }
-else
-  rails_constraint = "~> #{rails_version}.0"
-end
+rails_constraint =
+  if rails_version == "main"
+    {github: "rails/rails"}
+  else
+    "~> #{rails_version}.0"
+  end
 
 gem "rails", rails_constraint
+gem "activemodel", rails_constraint
+gem "sprockets-rails"
+
+group :test do
+  gem "activerecord-nulldb-adapter"
+  gem "minitest-around"
+end

--- a/lib/view_partial_form_builder/form_builder.rb
+++ b/lib/view_partial_form_builder/form_builder.rb
@@ -18,10 +18,15 @@ module ViewPartialFormBuilder
       )
     end
 
-    def label(method, text = nil, **options, &block)
+    def label(method, text_or_options = nil, options = {}, &block)
+      if text_or_options.is_a?(Hash)
+        options.merge! text_or_options
+        text_or_options = nil
+      end
+
       locals = {
         method: method,
-        text: text,
+        text: text_or_options,
         options: options,
         block: block,
       }
@@ -40,7 +45,7 @@ module ViewPartialFormBuilder
       render_partial("check_box", locals, fallback: -> { super })
     end
 
-    def radio_button(method, tag_value, **options)
+    def radio_button(method, tag_value, options = {})
       locals = {
         method: method,
         tag_value: tag_value,
@@ -50,7 +55,7 @@ module ViewPartialFormBuilder
       render_partial("radio_button", locals, fallback: -> { super })
     end
 
-    def select(method, choices = nil, options = {}, **html_options, &block)
+    def select(method, choices = nil, options = {}, html_options = {}, &block)
       html_options = @default_html_options.merge(html_options)
 
       locals = {
@@ -64,7 +69,7 @@ module ViewPartialFormBuilder
       render_partial("select", locals, fallback: -> { super }, &block)
     end
 
-    def collection_select(method, collection, value_method, text_method, options = {}, **html_options)
+    def collection_select(method, collection, value_method, text_method, options = {}, html_options = {})
       html_options = @default_html_options.merge(html_options)
 
       locals = {
@@ -79,7 +84,7 @@ module ViewPartialFormBuilder
       render_partial("collection_select", locals, fallback: -> { super })
     end
 
-    def collection_check_boxes(method, collection, value_method, text_method, options = {}, **html_options, &block)
+    def collection_check_boxes(method, collection, value_method, text_method, options = {}, html_options = {}, &block)
       html_options = @default_html_options.merge(html_options)
 
       locals = {
@@ -95,7 +100,7 @@ module ViewPartialFormBuilder
       render_partial("collection_check_boxes", locals, fallback: -> { super }, &block)
     end
 
-    def collection_radio_buttons(method, collection, value_method, text_method, options = {}, **html_options, &block)
+    def collection_radio_buttons(method, collection, value_method, text_method, options = {}, html_options = {}, &block)
       html_options = @default_html_options.merge(html_options)
 
       locals = {
@@ -111,7 +116,7 @@ module ViewPartialFormBuilder
       render_partial("collection_radio_buttons", locals, fallback: -> { super }, &block)
     end
 
-    def grouped_collection_select(method, collection, group_method, group_label_method, option_key_method, option_value_method, options = {}, **html_options)
+    def grouped_collection_select(method, collection, group_method, group_label_method, option_key_method, option_value_method, options = {}, html_options = {})
       html_options = @default_html_options.merge(html_options)
 
       locals = {
@@ -128,7 +133,7 @@ module ViewPartialFormBuilder
       render_partial("grouped_collection_select", locals, fallback: -> { super })
     end
 
-    def time_zone_select(method, priority_zones = nil, options = {}, **html_options)
+    def time_zone_select(method, priority_zones = nil, options = {}, html_options = {})
       html_options = @default_html_options.merge(html_options)
 
       locals = {
@@ -141,7 +146,7 @@ module ViewPartialFormBuilder
       render_partial("time_zone_select", locals, fallback: -> { super })
     end
 
-    def date_select(method, options = {}, **html_options)
+    def date_select(method, options = {}, html_options = {})
       locals = {
         method: method,
         options: options,
@@ -151,7 +156,7 @@ module ViewPartialFormBuilder
       render_partial("date_select", locals, fallback: -> { super })
     end
 
-    def hidden_field(method, **options)
+    def hidden_field(method, options = {})
       @emitted_hidden_id = true if method == :id
 
       locals = {
@@ -162,7 +167,7 @@ module ViewPartialFormBuilder
       render_partial("hidden_field", locals, fallback: -> { super })
     end
 
-    def file_field(method, **options)
+    def file_field(method, options = {})
       self.multipart = true
 
       locals = {
@@ -173,7 +178,7 @@ module ViewPartialFormBuilder
       render_partial("file_field", locals, fallback: -> { super })
     end
 
-    def submit(value = nil, **options)
+    def submit(value = nil, options = {})
       value, options = nil, value if value.is_a?(Hash)
       value ||= submit_default_value
 
@@ -185,7 +190,7 @@ module ViewPartialFormBuilder
       render_partial("submit", locals, fallback: -> { super })
     end
 
-    def button(value = nil, **options)
+    def button(value = nil, options = {})
       value, options = nil, value if value.is_a?(Hash)
       value ||= submit_default_value
 
@@ -205,7 +210,7 @@ module ViewPartialFormBuilder
 
     DYNAMICALLY_DECLARED.each do |selector|
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
-        def #{selector}(method, **options)
+        def #{selector}(method, options = {})
           render_partial(
             "#{selector}",
             {

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -4,22 +4,7 @@
 #   Ensure the SQLite 3 gem is defined in your Gemfile
 #   gem 'sqlite3'
 #
-default: &default
+test:
   adapter: nulldb
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
-
-development:
-  <<: *default
-  database: db/development.sqlite3
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
-test:
-  <<: *default
-  database: db/test.sqlite3
-
-production:
-  <<: *default
-  database: db/production.sqlite3

--- a/test/view_partial_form_builder/select_test.rb
+++ b/test/view_partial_form_builder/select_test.rb
@@ -54,6 +54,7 @@ class ViewPartialFormBuilderSelectTest < FormBuilderTestCase
         <%= form.select(
           method,
           choices,
+          {},
           "data-attr": "foo",
           &block
         ) %>

--- a/view_partial_form_builder.gemspec
+++ b/view_partial_form_builder.gemspec
@@ -16,11 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "actionview", ">= 4.0.0"
-  spec.add_dependency "railties", ">= 4.0.0"
+  spec.add_dependency "actionview"
+  spec.add_dependency "railties"
   spec.add_dependency "zeitwerk", ">= 2.4.0"
-
-  spec.add_development_dependency "minitest-around"
-  spec.add_development_dependency "activemodel", ">= 4.0.0"
-  spec.add_development_dependency "activerecord-nulldb-adapter"
 end


### PR DESCRIPTION
Include Ruby versions 3.0, 3.1, and 3.2 along with Rails versions `6.1`,
`7.0`, and `main`.
