### PR TITLE
Delegate `field_id` and `field_name` to view template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ version links.
 
 ## main
 
+Add test coverage for `field_id` and `field_name`
+
 ## [0.2.0] - Jan 22, 2023
 
 Implement the `FormBuilder` interface by proxying its underlying view

--- a/lib/view_partial_form_builder/form_builder.rb
+++ b/lib/view_partial_form_builder/form_builder.rb
@@ -7,9 +7,5 @@ module ViewPartialFormBuilder
       @default = dup
       @template = TemplateProxy.new(builder: self, template: @template)
     end
-
-    def _object_for_form_builder(object)
-      object.is_a?(Array) ? object.last : object
-    end
   end
 end

--- a/lib/view_partial_form_builder/template_proxy.rb
+++ b/lib/view_partial_form_builder/template_proxy.rb
@@ -1,5 +1,7 @@
 module ViewPartialFormBuilder
   class TemplateProxy
+    delegate :_object_for_form_builder, :field_id, :field_name, to: :@template
+
     def initialize(builder:, template:)
       @template = template
       @builder = builder

--- a/test/view_partial_form_builder/field_id_test.rb
+++ b/test/view_partial_form_builder/field_id_test.rb
@@ -1,0 +1,15 @@
+require "form_builder_test_case"
+
+class ViewPartialFormBuilderFieldIdTest < FormBuilderTestCase
+  if Rails.version >= "7.0.0"
+    test "delegates field_id to template" do
+      render(inline: <<~ERB)
+        <%= form_with(model: Post.new) do |form| %>
+          <%= form.field_id(:name) %>
+        <% end %>
+      ERB
+
+      assert_select("form", text: "post_name")
+    end
+  end
+end

--- a/test/view_partial_form_builder/field_name_test.rb
+++ b/test/view_partial_form_builder/field_name_test.rb
@@ -1,0 +1,15 @@
+require "form_builder_test_case"
+
+class ViewPartialFormBuilderFieldNameTest < FormBuilderTestCase
+  if Rails.version >= "7.0.0"
+    test "delegates field_name to template" do
+      render(inline: <<~ERB)
+        <%= form_with(model: Post.new) do |form| %>
+          <%= form.field_name(:name) %>
+        <% end %>
+      ERB
+
+      assert_select("form", text: "post[name]")
+    end
+  end
+end


### PR DESCRIPTION
Delegation to `field_id` and `field_name` wasn't passing option arguments properly. Since they're not field rendering methods, delegate directly to the view template.