### PR TITLE
Drop support for End-of-Life Ruby and Rails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,22 +12,15 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "2.7"
-          - "3.0"
           - "3.1"
           - "3.2"
           - "3.3"
         rails:
-          - "6.1"
-          - "7.0"
           - "7.1"
           - "7.2"
         include:
           - { ruby: "3.2", rails: "main" }
           - { ruby: "3.3", rails: "main" }
-        exclude:
-          - { ruby: "2.7", rails: "7.2" }
-          - { ruby: "3.0", rails: "7.2" }
 
     env:
       RAILS_VERSION: "${{ matrix.rails }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ version links.
 
 ## main
 
+Drop [end-of-life Ruby][] versions 2.7 and 3.0.
+
+Drop [end-of-life Rails][] versions 6.1 and 7.0
+
+[end-of-life Ruby]: https://www.ruby-lang.org/en/downloads/branches/
+[end-of-life Rails]: https://rubyonrails.org/maintenance
+
 ## [0.2.2] - Sep 27, 2024
 
 Expand matrix of supported versions to include `ruby@3.3` and `rails@7.2`.

--- a/view_partial_form_builder.gemspec
+++ b/view_partial_form_builder.gemspec
@@ -14,9 +14,11 @@ Gem::Specification.new do |spec|
   spec.description = "A Rails form builder where all designer-facing configuration is via templates."
   spec.license     = "MIT"
 
+  spec.required_ruby_version = ">= 3.1.0"
+
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "actionview"
-  spec.add_dependency "railties"
+  spec.add_dependency "actionview", ">= 7.1.0"
+  spec.add_dependency "railties", ">= 7.1.0"
   spec.add_dependency "zeitwerk", ">= 2.4.0"
 end


### PR DESCRIPTION
Drop [end-of-life][] Ruby versions 2.7 and 3.0 and drop end-of-life Rails versions 6.2 and 7.0.

[end-of-life]: https://www.ruby-lang.org/en/downloads/branches/